### PR TITLE
Historical data sync

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <uses-permission android:name="android.permission.health.READ_HYDRATION" />
     <uses-permission android:name="android.permission.health.READ_NUTRITION" />
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND" />
+    <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY" />
 
     <!-- Network Permission -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -559,6 +559,7 @@ class HealthConnectManager(private val context: Context) {
         fun getPermissionsForTypes(types: Set<HealthDataType>): Set<String> {
             val permissions = types.map { HealthPermission.getReadPermission(it.recordClass) }.toMutableSet()
             permissions.add("android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND")
+            permissions.add("android.permission.health.READ_HEALTH_DATA_HISTORY")
             return permissions
         }
 
@@ -581,7 +582,8 @@ class HealthConnectManager(private val context: Context) {
             HealthPermission.getReadPermission(ExerciseSessionRecord::class),
             HealthPermission.getReadPermission(HydrationRecord::class),
             HealthPermission.getReadPermission(NutritionRecord::class),
-            "android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"
+            "android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND",
+            "android.permission.health.READ_HEALTH_DATA_HISTORY"
         )
     }
 }

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -177,14 +177,20 @@ class HealthConnectManager(private val context: Context) {
     suspend fun readHealthData(
         enabledTypes: Set<HealthDataType>,
         lastSyncTimestamps: Map<HealthDataType, Instant?>,
-        timeRangeDays: Int? = null
+        timeRangeDays: Int? = null,
+        start: Instant? = null,
+        end: Instant? = null
     ): Result<HealthData> {
         return try {
-            val endTime = Instant.now()
-            val startTime = if (timeRangeDays != null) {
-                endTime.minus(timeRangeDays.toLong(), ChronoUnit.DAYS)
-            } else {
-                endTime.minus(LOOKBACK_HOURS, ChronoUnit.HOURS)
+            val endTime = end ?: Instant.now()
+            val startTime = when {
+                start != null -> start
+                timeRangeDays != null -> endTime.minus(timeRangeDays.toLong(), ChronoUnit.DAYS)
+                else -> endTime.minus(LOOKBACK_HOURS, ChronoUnit.HOURS)
+            }
+
+            if (startTime.isAfter(endTime)) {
+                return Result.failure(IllegalArgumentException("start must be before or equal to end"))
             }
 
             val stepsData = if (HealthDataType.STEPS in enabledTypes)

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -16,7 +16,14 @@ class SyncManager(private val context: Context) {
     private val preferencesManager = PreferencesManager(context)
     private val healthConnectManager = HealthConnectManager(context)
 
-    suspend fun performSync(timeRangeDays: Int? = null): Result<SyncResult> = withContext(Dispatchers.IO) {
+    suspend fun performSync(timeRangeDays: Int? = null, start: Instant? = null, end: Instant? = null): Result<SyncResult> = withContext(Dispatchers.IO) {
+        /*
+        Supports two modes:
+        - timeRangeDays: the amount of days in the past to sync.
+        - start/end: specific time range to sync
+        Note that custom period selection may override the last sync timestamp.
+        */
+
         try {
             val webhookConfigs = preferencesManager.getWebhookConfigs()
 
@@ -29,8 +36,10 @@ class SyncManager(private val context: Context) {
                 return@withContext Result.failure(Exception("No data types enabled"))
             }
 
-            // Get last sync timestamps for all enabled types, ignore if a manual time range is specified
-            val lastSyncTimestamps = if (timeRangeDays == null) {
+            // Keep incremental sync only for default mode.
+            // Explicit ranges (start/end or timeRangeDays) always perform a full read of that window.
+            val hasExplicitRange = start != null || end != null || timeRangeDays != null
+            val lastSyncTimestamps = if (!hasExplicitRange) {
                 enabledTypes.associateWith { type ->
                     preferencesManager.getLastSyncTimestamp(type)?.let { Instant.ofEpochMilli(it) }
                 }
@@ -39,7 +48,13 @@ class SyncManager(private val context: Context) {
             }
 
             // Read health data
-            val healthDataResult = healthConnectManager.readHealthData(enabledTypes, lastSyncTimestamps, timeRangeDays)
+            val healthDataResult = healthConnectManager.readHealthData(
+                enabledTypes = enabledTypes,
+                lastSyncTimestamps = lastSyncTimestamps,
+                timeRangeDays = timeRangeDays,
+                start = start,
+                end = end
+            )
             if (healthDataResult.isFailure) {
                 return@withContext Result.failure(healthDataResult.exceptionOrNull() ?: Exception("Failed to read health data"))
             }

--- a/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
+++ b/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
@@ -94,7 +94,25 @@ fun ManualSyncCard(onSyncCompleted: () -> Unit = {}) {
                                 }
 
                                 val syncManager = SyncManager(context)
-                                val result = syncManager.performSync(timeRangeOptions[selectedOptionIndex].second)
+                                val timeRangeSelection = timeRangeOptions[selectedOptionIndex].second
+
+                                val result = if (timeRangeSelection == -1) {
+                                    // custom date range
+                                    val startInstant = startDate?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
+                                    // normalize both boundaries to midnight UTC
+                                    val endInstant = endDate?.plusDays(1)?.atStartOfDay(ZoneOffset.UTC)?.toInstant()
+                                    if (startInstant == null || endInstant == null) {
+                                        syncMessage = "Please select both start and end dates."
+                                        isSyncing = false
+                                        return@launch
+                                    }
+
+                                    syncMessage = "Syncing data from ${startDate} to ${endDate}..."
+                                    syncManager.performSync(start = startInstant, end = endInstant)
+                                } else {
+                                    // sync the last N days, or from the last sync
+                                    syncManager.performSync(timeRangeSelection)
+                                }
 
                                 when {
                                     result.isSuccess -> {
@@ -227,19 +245,36 @@ fun ManualSyncCard(onSyncCompleted: () -> Unit = {}) {
                 }
 
                 if (showEndDatePicker) {
+                    val currentEndDate = endDate
+                    val minEndDateMillis = startDate
+                        ?.atStartOfDay(ZoneOffset.UTC)
+                        ?.toInstant()
+                        ?.toEpochMilli()
+                    val minEndYear = startDate?.year
                     val endPickerState = rememberDatePickerState(
-                        initialSelectedDateMillis = endDate
-                            ?.atStartOfDay(ZoneOffset.UTC)
-                            ?.toInstant()
-                            ?.toEpochMilli()
-                            ?: todayMillis,
+                        initialSelectedDateMillis = when {
+                            currentEndDate != null && minEndDateMillis != null -> {
+                                val endDateMillis = currentEndDate
+                                    .atStartOfDay(ZoneOffset.UTC)
+                                    .toInstant()
+                                    .toEpochMilli()
+                                maxOf(endDateMillis, minEndDateMillis)
+                            }
+                            currentEndDate != null -> currentEndDate
+                                .atStartOfDay(ZoneOffset.UTC)
+                                .toInstant()
+                                .toEpochMilli()
+                            minEndDateMillis != null -> minEndDateMillis
+                            else -> todayMillis
+                        },
                         selectableDates = object : SelectableDates {
                             override fun isSelectableDate(utcTimeMillis: Long): Boolean {
-                                return utcTimeMillis <= todayMillis
+                                return utcTimeMillis <= todayMillis &&
+                                    (minEndDateMillis == null || utcTimeMillis >= minEndDateMillis)
                             }
 
                             override fun isSelectableYear(year: Int): Boolean {
-                                return year <= today.year
+                                return year <= today.year && (minEndYear == null || year >= minEndYear)
                             }
                         }
                     )

--- a/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
+++ b/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
@@ -14,6 +14,10 @@ import com.hcwebhook.app.PreferencesManager
 import com.hcwebhook.app.SyncManager
 import com.hcwebhook.app.SyncResult
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,10 +36,15 @@ fun ManualSyncCard(onSyncCompleted: () -> Unit = {}) {
         "Default (New data only)" to null,
         "Past 1 Day" to 1,
         "Past 7 Days" to 7,
-        "Past 30 Days" to 30
+        "Past 30 Days" to 30,
+        "Custom selection" to -1
     )
     var expanded by remember { mutableStateOf(false) }
     var selectedOptionIndex by remember { mutableStateOf(0) }
+    var startDate by remember { mutableStateOf<LocalDate?>(null) }
+    var endDate by remember { mutableStateOf<LocalDate?>(null) }
+    var showStartDatePicker by remember { mutableStateOf(false) }
+    var showEndDatePicker by remember { mutableStateOf(false) }
 
     // ── Confirmation Bottom Sheet ──────────────────────────────────────────────
     if (showConfirmSheet) {
@@ -168,6 +177,139 @@ fun ManualSyncCard(onSyncCompleted: () -> Unit = {}) {
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
+
+            if (selectedOptionIndex == timeRangeOptions.indexOfFirst { it.second == -1 }) {
+                val today = LocalDate.now()
+                val todayMillis = remember(today) {
+                    today.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+                }
+
+                if (showStartDatePicker) {
+                    val startPickerState = rememberDatePickerState(
+                        initialSelectedDateMillis = startDate
+                            ?.atStartOfDay(ZoneOffset.UTC)
+                            ?.toInstant()
+                            ?.toEpochMilli()
+                            ?: todayMillis,
+                        selectableDates = object : SelectableDates {
+                            override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                                return utcTimeMillis <= todayMillis
+                            }
+
+                            override fun isSelectableYear(year: Int): Boolean {
+                                return year <= today.year
+                            }
+                        }
+                    )
+                    DatePickerDialog(
+                        onDismissRequest = { showStartDatePicker = false },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                val selectedMillis = startPickerState.selectedDateMillis
+                                startDate = selectedMillis?.let {
+                                    Instant.ofEpochMilli(it)
+                                        .atZone(ZoneOffset.UTC)
+                                        .toLocalDate()
+                                }
+                                showStartDatePicker = false
+                            }) {
+                                Text("OK")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showStartDatePicker = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    ) {
+                        DatePicker(state = startPickerState)
+                    }
+                }
+
+                if (showEndDatePicker) {
+                    val endPickerState = rememberDatePickerState(
+                        initialSelectedDateMillis = endDate
+                            ?.atStartOfDay(ZoneOffset.UTC)
+                            ?.toInstant()
+                            ?.toEpochMilli()
+                            ?: todayMillis,
+                        selectableDates = object : SelectableDates {
+                            override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                                return utcTimeMillis <= todayMillis
+                            }
+
+                            override fun isSelectableYear(year: Int): Boolean {
+                                return year <= today.year
+                            }
+                        }
+                    )
+                    DatePickerDialog(
+                        onDismissRequest = { showEndDatePicker = false },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                val selectedMillis = endPickerState.selectedDateMillis
+                                endDate = selectedMillis?.let {
+                                    Instant.ofEpochMilli(it)
+                                        .atZone(ZoneOffset.UTC)
+                                        .toLocalDate()
+                                }
+                                showEndDatePicker = false
+                            }) {
+                                Text("OK")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showEndDatePicker = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    ) {
+                        DatePicker(state = endPickerState)
+                    }
+                }
+
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    OutlinedButton(
+                        onClick = { showStartDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(startDate?.let { "Start Date: $it" } ?: "Select Start Date")
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    OutlinedButton(
+                        onClick = { showEndDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(endDate?.let { "End Date: $it" } ?: "Select End Date")
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    val startDateParsed = startDate
+                    val endDateParsed = endDate
+
+                    if (startDateParsed != null && endDateParsed != null) {
+                        when {
+                            endDateParsed < startDateParsed -> {
+                                Text(
+                                    "End date must be greater than or equal to start date.",
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                            endDateParsed > today -> {
+                                Text(
+                                    "End date cannot be in the future.",
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                        }
+                    }
+                }
+            }
 
             Button(
                 onClick = { showConfirmSheet = true },


### PR DESCRIPTION
The application allows the manual sync of historical data selecting a time period of 1/7/30 days.
With these additions, it is now possible to select an arbitrary date range to sync to the webhook server, specifying the start and end dates.
Additionally, when first configuring the application, a new permission `READ_HEALTH_DATA_HISTORY` is asked to allow for the selection of historical data (more than 30 days old), if available.