### PR TITLE
Fix WorkManager constraints and transient retry behavior

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HCWebhookApplication.kt
+++ b/app/src/main/java/com/hcwebhook/app/HCWebhookApplication.kt
@@ -1,7 +1,9 @@
 package com.hcwebhook.app
 
 import android.app.Application
+import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import java.util.concurrent.TimeUnit
@@ -38,10 +40,16 @@ class HCWebhookApplication : Application() {
 
         val syncIntervalMinutes = preferencesManager.getSyncIntervalMinutes()
 
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
         val syncWorkRequest = PeriodicWorkRequestBuilder<SyncWorker>(
             repeatInterval = syncIntervalMinutes.toLong(),
             repeatIntervalTimeUnit = TimeUnit.MINUTES
-        ).build()
+        )
+            .setConstraints(constraints)
+            .build()
 
         WorkManager.getInstance(this).enqueueUniquePeriodicWork(
             SYNC_WORK_NAME,

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -3,6 +3,7 @@ package com.hcwebhook.app
 import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
+import kotlinx.coroutines.CancellationException
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
@@ -300,6 +301,8 @@ class HealthConnectManager(private val context: Context) {
                 vo2Max = vo2MaxData,
                 boneMass = boneMassData
             ))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/hcwebhook/app/ScheduledSyncReceiver.kt
+++ b/app/src/main/java/com/hcwebhook/app/ScheduledSyncReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -46,6 +47,8 @@ class ScheduledSyncReceiver : BroadcastReceiver() {
                                 Log.d(TAG, "Rescheduled alarm for next day: $scheduleId")
                             }
                         }
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Log.e(TAG, "Sync failed: ${e.message}", e)
                     } finally {

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -1,6 +1,7 @@
 package com.hcwebhook.app
 
 import android.content.Context
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -105,6 +106,8 @@ class SyncManager(private val context: Context) {
             preferencesManager.setLastSyncSummary(summary)
 
             Result.success(SyncResult.Success(syncCounts))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
@@ -3,6 +3,7 @@ package com.hcwebhook.app
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -20,11 +21,16 @@ class SyncWorker(
             if (syncResult.isSuccess) {
                 Result.success()
             } else {
-                when (syncResult.exceptionOrNull()) {
+                when (val error = syncResult.exceptionOrNull()) {
+                    is HttpResponseException -> if (error.statusCode >= 500) Result.retry() else Result.failure()
                     is IOException -> Result.retry()
                     else -> Result.failure()
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpResponseException) {
+            if (e.statusCode >= 500) Result.retry() else Result.failure()
         } catch (e: IOException) {
             Result.retry()
         } catch (e: Exception) {

--- a/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
@@ -34,7 +34,6 @@ class SyncWorker(
 
     private fun mapFailure(error: Throwable?): Result {
         return when (error) {
-            is HttpResponseException -> if (WebhookManager.isRetryableException(error)) Result.retry() else Result.failure()
             is IOException -> if (WebhookManager.isRetryableException(error)) Result.retry() else Result.failure()
             else -> Result.failure()
         }

--- a/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
@@ -14,7 +14,6 @@ class SyncWorker(
 ) : CoroutineWorker(appContext, workerParams) {
 
     private val syncManager = SyncManager(appContext)
-    private val webhookManager = WebhookManager(emptyList())
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
@@ -35,8 +34,8 @@ class SyncWorker(
 
     private fun mapFailure(error: Throwable?): Result {
         return when (error) {
-            is HttpResponseException -> if (webhookManager.isRetryableException(error)) Result.retry() else Result.failure()
-            is IOException -> if (webhookManager.isRetryableException(error)) Result.retry() else Result.failure()
+            is HttpResponseException -> if (WebhookManager.isRetryableException(error)) Result.retry() else Result.failure()
+            is IOException -> if (WebhookManager.isRetryableException(error)) Result.retry() else Result.failure()
             else -> Result.failure()
         }
     }

--- a/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
@@ -34,6 +34,7 @@ class SyncWorker(
 
     private fun mapFailure(error: Throwable?): Result {
         return when (error) {
+            is CancellationException -> throw error
             is IOException -> if (WebhookManager.isRetryableException(error)) Result.retry() else Result.failure()
             else -> Result.failure()
         }

--- a/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
@@ -14,6 +14,7 @@ class SyncWorker(
 ) : CoroutineWorker(appContext, workerParams) {
 
     private val syncManager = SyncManager(appContext)
+    private val webhookManager = WebhookManager(emptyList())
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
@@ -21,20 +22,22 @@ class SyncWorker(
             if (syncResult.isSuccess) {
                 Result.success()
             } else {
-                when (val error = syncResult.exceptionOrNull()) {
-                    is HttpResponseException -> if (error.statusCode >= 500) Result.retry() else Result.failure()
-                    is IOException -> Result.retry()
-                    else -> Result.failure()
-                }
+                mapFailure(syncResult.exceptionOrNull())
             }
         } catch (e: CancellationException) {
             throw e
-        } catch (e: HttpResponseException) {
-            if (e.statusCode >= 500) Result.retry() else Result.failure()
         } catch (e: IOException) {
-            Result.retry()
+            mapFailure(e)
         } catch (e: Exception) {
             Result.failure()
+        }
+    }
+
+    private fun mapFailure(error: Throwable?): Result {
+        return when (error) {
+            is HttpResponseException -> if (webhookManager.isRetryableException(error)) Result.retry() else Result.failure()
+            is IOException -> if (webhookManager.isRetryableException(error)) Result.retry() else Result.failure()
+            else -> Result.failure()
         }
     }
 }

--- a/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncWorker.kt
@@ -5,6 +5,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.IOException
 
 class SyncWorker(
     appContext: Context,
@@ -16,11 +17,16 @@ class SyncWorker(
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
             val syncResult = syncManager.performSync()
-            when {
-                syncResult.isSuccess -> Result.success()
-                syncResult.isFailure -> Result.failure()
-                else -> Result.success() // No data case
+            if (syncResult.isSuccess) {
+                Result.success()
+            } else {
+                when (syncResult.exceptionOrNull()) {
+                    is IOException -> Result.retry()
+                    else -> Result.failure()
+                }
             }
+        } catch (e: IOException) {
+            Result.retry()
         } catch (e: Exception) {
             Result.failure()
         }

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -78,9 +78,6 @@ class WebhookManager(
             config.headers.forEach { (key, value) ->
                 requestBuilder.addHeader(key, value)
             }
-            for ((key, value) in config.headers) {
-                requestBuilder.addHeader(key, value)
-            }
             
             val request = requestBuilder.build()
 

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -40,7 +40,7 @@ class WebhookManager(
             return Result.failure(IllegalStateException("No webhook URLs configured"))
         }
 
-        var lastFailure: Exception? = null
+        var lastFailure: Throwable? = null
 
         // Try posting to all configured webhooks
         for (config in webhookConfigs) {
@@ -48,7 +48,7 @@ class WebhookManager(
             if (result.isSuccess) {
                 return result // Success if at least one webhook succeeds
             } else {
-                lastFailure = result.exceptionOrNull() as? Exception ?: Exception("Unknown error")  
+                lastFailure = result.exceptionOrNull()
             }
         }
 

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLException
 import kotlin.math.pow
 
-class HttpResponseException(
+internal class HttpResponseException(
     val statusCode: Int,
     message: String
 ) : IOException(message)
@@ -76,6 +76,7 @@ class WebhookManager(
 
             var lastException: Exception? = null
             for (attempt in 1..MAX_RETRIES) {
+                var shouldRetry = true
                 try {
                     client.newCall(request).execute().use { response ->
                         statusCode = response.code
@@ -90,11 +91,12 @@ class WebhookManager(
                             )
                             lastException = httpException
                             errorMessage = httpException.message
-
-                            if (!isRetryableException(httpException)) {
-                                break
-                            }
+                            shouldRetry = isRetryableException(httpException)
                         }
+                    }
+
+                    if (!shouldRetry) {
+                        break
                     }
                 } catch (e: IOException) {
                     lastException = e

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -41,6 +41,7 @@ class WebhookManager(
         }
 
         var lastFailure: Throwable? = null
+        var retryableFailure: IOException? = null
 
         // Try posting to all configured webhooks
         for (config in webhookConfigs) {
@@ -48,11 +49,17 @@ class WebhookManager(
             if (result.isSuccess) {
                 return result // Success if at least one webhook succeeds
             } else {
-                lastFailure = result.exceptionOrNull()
+                val ex = result.exceptionOrNull()
+                lastFailure = ex
+                if (ex is IOException && isRetryableException(ex)) {
+                    retryableFailure = ex
+                }
             }
         }
 
-        return Result.failure(lastFailure ?: IOException("All webhook posts failed"))
+        // Prefer a retryable exception so that SyncWorker can schedule a retry
+        // even if the last webhook failed with a non-retryable error
+        return Result.failure(retryableFailure ?: lastFailure ?: IOException("All webhook posts failed"))
     }
 
     private suspend fun postToUrl(config: WebhookConfig, jsonPayload: String): Result<Unit> {

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -78,6 +78,9 @@ class WebhookManager(
             config.headers.forEach { (key, value) ->
                 requestBuilder.addHeader(key, value)
             }
+            for ((key, value) in config.headers) {
+                requestBuilder.addHeader(key, value)
+            }
             
             val request = requestBuilder.build()
 

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -1,14 +1,18 @@
 package com.hcwebhook.app
 
 import android.content.Context
+import kotlinx.coroutines.CancellationException
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.net.ProtocolException
 import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLException
 import kotlin.math.pow
 
 class HttpResponseException(
@@ -73,22 +77,23 @@ class WebhookManager(
             var lastException: Exception? = null
             for (attempt in 1..MAX_RETRIES) {
                 try {
-                    val response = client.newCall(request).execute()
-                    statusCode = response.code
-                    if (response.isSuccessful) {
-                        success = true
-                        logWebhookCall(config.url, timestamp, statusCode, true, null)
-                        return Result.success(Unit)
-                    } else {
-                        val httpException = HttpResponseException(
-                            response.code,
-                            "HTTP ${response.code}: ${response.message}"
-                        )
-                        lastException = httpException
-                        errorMessage = httpException.message
+                    client.newCall(request).execute().use { response ->
+                        statusCode = response.code
+                        if (response.isSuccessful) {
+                            success = true
+                            logWebhookCall(config.url, timestamp, statusCode, true, null)
+                            return Result.success(Unit)
+                        } else {
+                            val httpException = HttpResponseException(
+                                response.code,
+                                "HTTP ${response.code}: ${response.message}"
+                            )
+                            lastException = httpException
+                            errorMessage = httpException.message
 
-                        if (!isRetryableException(httpException)) {
-                            break
+                            if (!isRetryableException(httpException)) {
+                                break
+                            }
                         }
                     }
                 } catch (e: IOException) {
@@ -109,6 +114,8 @@ class WebhookManager(
 
             logWebhookCall(config.url, timestamp, statusCode, false, errorMessage)
             Result.failure(lastException ?: IOException("Max retries exceeded"))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             logWebhookCall(config.url, timestamp, null, false, e.message)
             Result.failure(e)
@@ -144,10 +151,13 @@ class WebhookManager(
         private const val INITIAL_RETRY_DELAY_MS = 1000L
     }
 
-    private fun isRetryableException(exception: IOException): Boolean {
+    fun isRetryableException(exception: IOException): Boolean {
         return when (exception) {
             is HttpResponseException -> exception.statusCode >= 500
             is SocketTimeoutException -> true
+            is UnknownHostException -> true
+            is SSLException -> false
+            is ProtocolException -> false
             else -> true
         }
     }

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -6,9 +6,15 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.net.SocketTimeoutException
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.math.pow
+
+class HttpResponseException(
+    val statusCode: Int,
+    message: String
+) : IOException(message)
 
 class WebhookManager(
     private val webhookConfigs: List<WebhookConfig>,
@@ -74,12 +80,24 @@ class WebhookManager(
                         logWebhookCall(config.url, timestamp, statusCode, true, null)
                         return Result.success(Unit)
                     } else {
-                        lastException = IOException("HTTP ${response.code}: ${response.message}")
-                        errorMessage = "HTTP ${response.code}: ${response.message}"
+                        val httpException = HttpResponseException(
+                            response.code,
+                            "HTTP ${response.code}: ${response.message}"
+                        )
+                        lastException = httpException
+                        errorMessage = httpException.message
+
+                        if (!isRetryableException(httpException)) {
+                            break
+                        }
                     }
                 } catch (e: IOException) {
                     lastException = e
                     errorMessage = e.message
+
+                    if (!isRetryableException(e)) {
+                        break
+                    }
                 }
 
                 if (attempt < MAX_RETRIES) {
@@ -124,5 +142,13 @@ class WebhookManager(
         private const val TIMEOUT_SECONDS = 60L
         private const val MAX_RETRIES = 3
         private const val INITIAL_RETRY_DELAY_MS = 1000L
+    }
+
+    private fun isRetryableException(exception: IOException): Boolean {
+        return when (exception) {
+            is HttpResponseException -> exception.statusCode >= 500
+            is SocketTimeoutException -> true
+            else -> true
+        }
     }
 }

--- a/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/WebhookManager.kt
@@ -149,16 +149,16 @@ class WebhookManager(
         private const val TIMEOUT_SECONDS = 60L
         private const val MAX_RETRIES = 3
         private const val INITIAL_RETRY_DELAY_MS = 1000L
-    }
 
-    fun isRetryableException(exception: IOException): Boolean {
-        return when (exception) {
-            is HttpResponseException -> exception.statusCode >= 500
-            is SocketTimeoutException -> true
-            is UnknownHostException -> true
-            is SSLException -> false
-            is ProtocolException -> false
-            else -> true
+        internal fun isRetryableException(exception: IOException): Boolean {
+            return when (exception) {
+                is HttpResponseException -> exception.statusCode >= 500
+                is SocketTimeoutException -> true
+                is UnknownHostException -> true
+                is SSLException -> false
+                is ProtocolException -> false
+                else -> true
+            }
         }
     }
 }

--- a/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
+++ b/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
@@ -13,6 +13,7 @@ import com.hcwebhook.app.HealthConnectManager
 import com.hcwebhook.app.PreferencesManager
 import com.hcwebhook.app.SyncManager
 import com.hcwebhook.app.SyncResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.LocalDate
@@ -138,6 +139,8 @@ fun ManualSyncCard(onSyncCompleted: () -> Unit = {}) {
                                         syncMessage = "Sync failed: ${result.exceptionOrNull()?.message ?: "Unknown error"}"
                                     }
                                 }
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
                                 syncMessage = "Sync failed: ${e.message}"
                             } finally {


### PR DESCRIPTION
## Summary
- add a connected-network constraint to periodic sync work
- classify retryable webhook failures without constructing an unused WebhookManager
- preserve CancellationException propagation through the sync path
- avoid breaking inside the response `use {}` block and keep `HttpResponseException` internal

## Why
This improves background sync reliability, avoids wasted retries on non-retryable failures, and preserves cooperative cancellation during webhook delivery.

## Scope
This PR is intentionally limited to the WorkManager, retry-classification, and cancellation-handling changes only.