### PR TITLE
fix: paginate readRecords across all Health Connect readers

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -420,9 +420,9 @@ class HealthConnectManager(private val context: Context) {
             timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
         )
 
-        val response = healthConnectClient.readRecords(request)
+        val response = readAllRecords(request)
 
-        return response.records
+        return response
             .filter { record ->
                 lastSync == null || record.endTime >= lastSync
             }
@@ -446,8 +446,8 @@ class HealthConnectManager(private val context: Context) {
 
     private suspend fun readHeartRateData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<HeartRateData> {
         val request = ReadRecordsRequest(recordType = HeartRateRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records
+        val response = readAllRecords(request)
+        return response
             .flatMap { record ->
                 record.samples
                     .filter { lastSync == null || it.time >= lastSync }
@@ -457,8 +457,8 @@ class HealthConnectManager(private val context: Context) {
 
     private suspend fun readHeartRateVariabilityData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<HeartRateVariabilityData> {
         val request = ReadRecordsRequest(recordType = HeartRateVariabilityRmssdRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { HeartRateVariabilityData(it.heartRateVariabilityMillis, it.time) }
     }
 
@@ -548,71 +548,71 @@ class HealthConnectManager(private val context: Context) {
 
     private suspend fun readTotalCaloriesData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<TotalCaloriesData> {
         val request = ReadRecordsRequest(recordType = TotalCaloriesBurnedRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.endTime >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.endTime >= lastSync }
             .map { TotalCaloriesData(it.energy.inKilocalories, it.startTime, it.endTime) }
     }
 
     private suspend fun readWeightData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<WeightData> {
         val request = ReadRecordsRequest(recordType = WeightRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { WeightData(it.weight.inKilograms, it.time) }
     }
 
     private suspend fun readHeightData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<HeightData> {
         val request = ReadRecordsRequest(recordType = HeightRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { HeightData(it.height.inMeters, it.time) }
     }
 
     private suspend fun readBloodPressureData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BloodPressureData> {
         val request = ReadRecordsRequest(recordType = BloodPressureRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { BloodPressureData(it.systolic.inMillimetersOfMercury, it.diastolic.inMillimetersOfMercury, it.time) }
     }
 
     private suspend fun readBloodGlucoseData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BloodGlucoseData> {
         val request = ReadRecordsRequest(recordType = BloodGlucoseRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { BloodGlucoseData(it.level.inMillimolesPerLiter, it.time) }
     }
 
     private suspend fun readOxygenSaturationData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<OxygenSaturationData> {
         val request = ReadRecordsRequest(recordType = OxygenSaturationRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { OxygenSaturationData(it.percentage.value, it.time) }
     }
 
     private suspend fun readBodyTemperatureData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BodyTemperatureData> {
         val request = ReadRecordsRequest(recordType = BodyTemperatureRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { BodyTemperatureData(it.temperature.inCelsius, it.time) }
     }
 
     private suspend fun readRespiratoryRateData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<RespiratoryRateData> {
         val request = ReadRecordsRequest(recordType = RespiratoryRateRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { RespiratoryRateData(it.rate, it.time) }
     }
 
     private suspend fun readRestingHeartRateData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<RestingHeartRateData> {
         val request = ReadRecordsRequest(recordType = RestingHeartRateRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { RestingHeartRateData(it.beatsPerMinute, it.time) }
     }
 
     private suspend fun readExerciseData(startTime: Instant, endTime: Instant, lastSync: Instant?, includeDistance: Boolean): List<ExerciseData> {
         val request = ReadRecordsRequest(recordType = ExerciseSessionRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.endTime >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.endTime >= lastSync }
             .map {
                 ExerciseData(
                     type = it.exerciseType.toString(),
@@ -636,51 +636,70 @@ class HealthConnectManager(private val context: Context) {
 
     private suspend fun readHydrationData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<HydrationData> {
         val request = ReadRecordsRequest(recordType = HydrationRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.endTime >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.endTime >= lastSync }
             .map { HydrationData(it.volume.inLiters, it.startTime, it.endTime) }
     }
 
     private suspend fun readNutritionData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<NutritionData> {
         val request = ReadRecordsRequest(recordType = NutritionRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.endTime >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.endTime >= lastSync }
             .map { NutritionData(it.energy?.inKilocalories, it.protein?.inGrams, it.totalCarbohydrate?.inGrams, it.totalFat?.inGrams, it.startTime, it.endTime) }
     }
 
     private suspend fun readBasalMetabolicRateData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BasalMetabolicRateData> {
         val request = ReadRecordsRequest(recordType = BasalMetabolicRateRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { BasalMetabolicRateData(it.basalMetabolicRate.inWatts, it.time) }
     }
 
     private suspend fun readBodyFatData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BodyFatData> {
         val request = ReadRecordsRequest(recordType = BodyFatRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { BodyFatData(it.percentage.value, it.time) }
     }
 
     private suspend fun readLeanBodyMassData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<LeanBodyMassData> {
         val request = ReadRecordsRequest(recordType = LeanBodyMassRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { LeanBodyMassData(it.mass.inKilograms, it.time) }
     }
 
     private suspend fun readVo2MaxData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<Vo2MaxData> {
         val request = ReadRecordsRequest(recordType = Vo2MaxRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { Vo2MaxData(it.vo2MillilitersPerMinuteKilogram, it.time) }
     }
 
     private suspend fun readBoneMassData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BoneMassData> {
         val request = ReadRecordsRequest(recordType = BoneMassRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
-        val response = healthConnectClient.readRecords(request)
-        return response.records.filter { lastSync == null || it.time >= lastSync }
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
             .map { BoneMassData(it.mass.inKilograms, it.time) }
+    }
+
+    private suspend fun <T : Record> readAllRecords(request: ReadRecordsRequest<T>): List<T> {
+        val all = mutableListOf<T>()
+        var token: String? = null
+        do {
+            val current = if (token == null) request else ReadRecordsRequest(
+                recordType = request.recordType,
+                timeRangeFilter = request.timeRangeFilter,
+                dataOriginFilter = request.dataOriginFilter,
+                ascendingOrder = request.ascendingOrder,
+                pageSize = request.pageSize,
+                pageToken = token,
+            )
+            val page = healthConnectClient.readRecords(current)
+            all.addAll(page.records)
+            token = page.pageToken
+        } while (token != null)
+        return all
     }
 
     fun isHealthConnectAvailable(): Boolean {


### PR DESCRIPTION
## Summary

The current `HealthConnectManager` calls `healthConnectClient.readRecords(request)` once per data type and discards `response.pageToken`, so Health Connect's default 1000-record page size silently truncates large queries.

For high-frequency data like **HeartRate**, **Steps**, or **HeartRateVariability** over a multi-day historical sync, this returns only the oldest 1000 samples (results come back in ascending order) and drops everything newer. The app shows "sync successful" but the webhook receives an incomplete dataset, with no error surfaced to the user.

## Root cause

From the [Health Connect docs](https://developer.android.com/reference/androidx/health/connect/client/request/ReadRecordsRequest):

> If the number of records exceeds `pageSize`, the response will contain a non-null `pageToken`. To retrieve the next page, pass this token into a new `ReadRecordsRequest`.

Every `readRecords` call in `HealthConnectManager.kt` ignores `response.pageToken`, so only the first page is ever read.

## Fix

Add a `readAllRecords()` helper that loops on `pageToken` until exhausted, reusing the original request's `recordType`, `timeRangeFilter`, `dataOriginFilter`, `ascendingOrder`, and `pageSize`:

```kotlin
private suspend fun <T : Record> readAllRecords(request: ReadRecordsRequest<T>): List<T> {
    val all = mutableListOf<T>()
    var token: String? = null
    do {
        val current = if (token == null) request else ReadRecordsRequest(
            recordType = request.recordType,
            timeRangeFilter = request.timeRangeFilter,
            dataOriginFilter = request.dataOriginFilter,
            ascendingOrder = request.ascendingOrder,
            pageSize = request.pageSize,
            pageToken = token,
        )
        val page = healthConnectClient.readRecords(current)
        all.addAll(page.records)
        token = page.pageToken
    } while (token != null)
    return all
}
```

Then route all 20 read call sites through it (Steps, HeartRate, HeartRateVariability, Sleep, Weight, BloodPressure, BloodGlucose, OxygenSaturation, BodyTemperature, RespiratoryRate, RestingHeartRate, Exercise, Hydration, Nutrition, BasalMetabolicRate, BodyFat, LeanBodyMass, Vo2Max, BoneMass, and the others). Each changed from:

```kotlin
val response = healthConnectClient.readRecords(request)
return response.records.filter { ... }.map { ... }
```

to:

```kotlin
val response = readAllRecords(request)
return response.filter { ... }.map { ... }
```

The change is mechanical — no behavioral difference for datasets under 1000 records, just correctness for larger ones. Small datasets still exit the `do/while` after one iteration (no extra API call).

`Exercise`'s aggregate `readDistanceTotal()` is left alone — it uses `aggregate()`, not `readRecords()`, and isn't subject to the page limit.

## Testing

Reproduced the bug against a Pixel 8 with ~3 weeks of continuous HeartRate and HeartRateVariability samples (well past 1000 records for either type). Before the fix, manual historical sync for a multi-day window consistently stopped at the first 1000 samples per type. After the fix, all samples in the requested range are posted to the webhook — verified by comparing counts from the webhook receiver's database against counts visible in the Health Connect app for the same time window.

## Diff size

+59 / −40 in a single file (`HealthConnectManager.kt`).