### PR TITLE
Add session movement metrics to exercise payloads

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -204,7 +204,11 @@ data class ExerciseData(
     val startTime: Instant,
     val endTime: Instant,
     val duration: Duration,
-    val distanceMeters: Double? = null
+    val distanceMeters: Double? = null,
+    val steps: Long? = null,
+    val avgCadenceSpm: Double? = null,
+    val maxCadenceSpm: Double? = null,
+    val strideLengthMeters: Double? = null
 )
 
 data class HydrationData(
@@ -311,7 +315,8 @@ class HealthConnectManager(private val context: Context) {
                     startTime,
                     endTime,
                     lastSyncTimestamps[HealthDataType.EXERCISE],
-                    HealthDataType.DISTANCE in enabledTypes
+                    HealthDataType.DISTANCE in enabledTypes,
+                    HealthDataType.STEPS in enabledTypes
                 ) else emptyList()
             val hydrationData = if (HealthDataType.HYDRATION in enabledTypes)
                 readHydrationData(startTime, endTime, lastSyncTimestamps[HealthDataType.HYDRATION]) else emptyList()
@@ -609,19 +614,80 @@ class HealthConnectManager(private val context: Context) {
             .map { RestingHeartRateData(it.beatsPerMinute, it.time) }
     }
 
-    private suspend fun readExerciseData(startTime: Instant, endTime: Instant, lastSync: Instant?, includeDistance: Boolean): List<ExerciseData> {
+    private suspend fun readExerciseData(
+        startTime: Instant,
+        endTime: Instant,
+        lastSync: Instant?,
+        includeDistance: Boolean,
+        includeSteps: Boolean
+    ): List<ExerciseData> {
         val request = ReadRecordsRequest(recordType = ExerciseSessionRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.endTime >= lastSync }
             .map {
+                val duration = Duration.between(it.startTime, it.endTime)
+                val distanceMeters = if (includeDistance) readDistanceTotal(it.startTime, it.endTime) else null
+                val steps = if (includeSteps) readStepsTotal(it.startTime, it.endTime) else null
+                val cadenceMetrics = if (includeSteps) readStepsCadenceMetrics(it.startTime, it.endTime) else StepsCadenceMetrics()
                 ExerciseData(
                     type = it.exerciseType.toString(),
                     startTime = it.startTime,
                     endTime = it.endTime,
-                    duration = Duration.between(it.startTime, it.endTime),
-                    distanceMeters = if (includeDistance) readDistanceTotal(it.startTime, it.endTime) else null
+                    duration = duration,
+                    distanceMeters = distanceMeters,
+                    steps = steps,
+                    avgCadenceSpm = cadenceMetrics.avg ?: deriveAverageCadenceSpm(steps, duration),
+                    maxCadenceSpm = cadenceMetrics.max,
+                    strideLengthMeters = deriveStrideLengthMeters(distanceMeters, steps)
                 )
             }
+    }
+
+    private data class StepsCadenceMetrics(
+        val avg: Double? = null,
+        val max: Double? = null
+    )
+
+    private suspend fun readStepsTotal(startTime: Instant, endTime: Instant): Long? {
+        val request = AggregateRequest(
+            metrics = setOf(StepsRecord.COUNT_TOTAL),
+            timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
+        )
+        val response = healthConnectClient.aggregate(request)
+        val steps = response[StepsRecord.COUNT_TOTAL] ?: return null
+        return steps.takeIf { it > 0L }
+    }
+
+    private suspend fun readStepsCadenceMetrics(startTime: Instant, endTime: Instant): StepsCadenceMetrics {
+        return try {
+            val request = AggregateRequest(
+                metrics = setOf(StepsCadenceRecord.RATE_AVG, StepsCadenceRecord.RATE_MAX),
+                timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
+            )
+            val response = healthConnectClient.aggregate(request)
+            StepsCadenceMetrics(
+                avg = response[StepsCadenceRecord.RATE_AVG]?.takeIf { it > 0.0 },
+                max = response[StepsCadenceRecord.RATE_MAX]?.takeIf { it > 0.0 }
+            )
+        } catch (_: Exception) {
+            // Cadence is optional. Keep exercise sync working on providers that expose steps but not cadence.
+            StepsCadenceMetrics()
+        }
+    }
+
+    private fun deriveAverageCadenceSpm(steps: Long?, duration: Duration): Double? {
+        if (steps == null || steps <= 0L || duration.isZero || duration.isNegative) {
+            return null
+        }
+        val durationMinutes = duration.toMillis() / 60000.0
+        return (steps.toDouble() / durationMinutes).takeIf { it > 0.0 }
+    }
+
+    private fun deriveStrideLengthMeters(distanceMeters: Double?, steps: Long?): Double? {
+        if (distanceMeters == null || distanceMeters <= 0.0 || steps == null || steps <= 0L) {
+            return null
+        }
+        return distanceMeters / steps.toDouble()
     }
 
     private suspend fun readDistanceTotal(startTime: Instant, endTime: Instant): Double? {

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -804,6 +804,9 @@ class HealthConnectManager(private val context: Context) {
             includeBackgroundPermission: Boolean = true
         ): Set<String> {
             val permissions = types.map { HealthPermission.getReadPermission(it.recordClass) }.toMutableSet()
+            if (HealthDataType.STEPS in types) {
+                permissions.add(HealthPermission.getReadPermission(StepsCadenceRecord::class))
+            }
             if (includeBackgroundPermission) {
                 permissions.add(BACKGROUND_PERMISSION_STR)
             }
@@ -818,6 +821,7 @@ class HealthConnectManager(private val context: Context) {
 
         val ALL_PERMISSIONS = setOf(
             HealthPermission.getReadPermission(StepsRecord::class),
+            HealthPermission.getReadPermission(StepsCadenceRecord::class),
             HealthPermission.getReadPermission(SleepSessionRecord::class),
             HealthPermission.getReadPermission(HeartRateRecord::class),
             HealthPermission.getReadPermission(HeartRateVariabilityRmssdRecord::class),

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -432,6 +432,18 @@ class SyncManager(private val context: Context) {
                         it.distanceMeters?.let { distanceMeters ->
                             put("distance_meters", distanceMeters)
                         }
+                        it.steps?.let { steps ->
+                            put("steps", steps)
+                        }
+                        it.avgCadenceSpm?.let { avgCadenceSpm ->
+                            put("avg_cadence_spm", avgCadenceSpm)
+                        }
+                        it.maxCadenceSpm?.let { maxCadenceSpm ->
+                            put("max_cadence_spm", maxCadenceSpm)
+                        }
+                        it.strideLengthMeters?.let { strideLengthMeters ->
+                            put("stride_length_m", strideLengthMeters)
+                        }
                     }) }
                 }
             }


### PR DESCRIPTION
## Summary

Add session-scoped movement metrics to exercise webhook payloads:

- `steps`
- `avg_cadence_spm`
- `max_cadence_spm`
- `stride_length_m`

This PR intentionally does not add downstream analytics fields such as `calories_per_km`, `training_load`, run type, or quality flags. Those are better calculated by consumers from the exercise payload.

## Problem

HC Webhook already exports Exercise Sessions and daily/range-level Steps separately. That works for general activity tracking, but consumers cannot reliably map daily/range step totals back to individual exercise sessions.

For running analytics, each exercise payload needs session-scoped movement metrics so downstream tools can calculate cadence, stride, and run quality per workout. Cadence also needs explicit `StepsCadenceRecord` read access; otherwise cadence values may remain empty even when a provider writes cadence records.

## Change

- Aggregate `StepsRecord.COUNT_TOTAL` over each exercise session's own `startTime` and `endTime`.
- Aggregate `StepsCadenceRecord.RATE_AVG` and `StepsCadenceRecord.RATE_MAX` over each exercise session when the data is available.
- Request `StepsCadenceRecord` read permission together with Steps.
- Fall back to derived average cadence from `steps / duration_minutes` when cadence records are unavailable.
- Derive `stride_length_m` from `distance_meters / steps` when both values are available.
- Keep the existing top-level `steps` payload behavior unchanged for backward compatibility.

## Example exercise payload

```json
{
  "type": "56",
  "start_time": "2026-04-20T00:19:45.112Z",
  "end_time": "2026-04-20T00:55:28.220Z",
  "duration_seconds": 2143,
  "distance_meters": 6000.39501953125,
  "steps": 6200,
  "avg_cadence_spm": 173.6,
  "max_cadence_spm": 186.0,
  "stride_length_m": 0.968
}
```

## Notes

- `avg_cadence_spm` and `max_cadence_spm` depend on Health Connect cadence data being present. If cadence records are unavailable, only `avg_cadence_spm` can be derived from steps and duration.
- `stride_length_m` is derived because Health Connect does not expose stride length as a separate exercise field in this app.
- `elevation_gain_m`, `avg_speed_kmh`, and `max_speed_kmh` are possible future session fields through `ElevationGainedRecord` and `SpeedRecord`, but they are intentionally out of scope for this focused cadence/stride PR.

## Validation

- `git diff --check` passes.
- Confirmed `StepsCadenceRecord` exists in the project's current `androidx.health.connect:connect-client:1.1.0-alpha11` source jar and has separate aggregate metrics for average and max cadence.
- Local Gradle build was not run because this machine does not currently have a Java runtime installed.