### PR TITLE
Send per-record StepsRecord data for accurate timezone-aware bucketing

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -370,49 +370,25 @@ class HealthConnectManager(private val context: Context) {
         endTime: Instant,
         lastSync: Instant?
     ): List<StepsData> {
-        // Aggregate steps per calendar day (using device timezone) instead of
-        // a single multi-day total. This produces clean per-day records that
-        // the server can use directly without delta-tracking hacks.
-        val zone = java.time.ZoneId.systemDefault()
-        val result = mutableListOf<StepsData>()
-
-        val startLocalDate = startTime.atZone(zone).toLocalDate()
-        val endLocalDate = endTime.atZone(zone).toLocalDate()
-
-        var currentDate = startLocalDate
-        while (!currentDate.isAfter(endLocalDate)) {
-            val dayStart = currentDate.atStartOfDay(zone).toInstant()
-            val dayEnd = currentDate.plusDays(1).atStartOfDay(zone).toInstant()
-
-            // Clamp to the actual lookback window
-            val queryStart = if (dayStart.isBefore(startTime)) startTime else dayStart
-            val queryEnd = if (dayEnd.isAfter(endTime)) endTime else dayEnd
-
-            // Skip days entirely before lastSync
-            if (lastSync != null && queryEnd.isBefore(lastSync)) {
-                currentDate = currentDate.plusDays(1)
-                continue
+        // Emit raw StepsRecord entries instead of per-calendar-day aggregates.
+        // Each StepsRecord (typically 1-15 min written by the phone pedometer)
+        // carries its own startTime/endTime/count, so the receiver can bucket
+        // by any logical-day boundary (e.g. day_start_hour=4) without losing
+        // the early-morning portion of a calendar day.
+        val request = ReadRecordsRequest(
+            recordType = StepsRecord::class,
+            timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
+        )
+        val response = readAllRecords(request)
+        return response
+            .filter { lastSync == null || it.endTime >= lastSync }
+            .map { record ->
+                StepsData(
+                    count = record.count,
+                    startTime = record.startTime,
+                    endTime = record.endTime
+                )
             }
-
-            val request = AggregateRequest(
-                metrics = setOf(StepsRecord.COUNT_TOTAL),
-                timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
-            )
-            val response = healthConnectClient.aggregate(request)
-            val daySteps = response[StepsRecord.COUNT_TOTAL] ?: 0L
-
-            if (daySteps > 0) {
-                result.add(StepsData(
-                    count = daySteps,
-                    startTime = dayStart,
-                    endTime = queryEnd
-                ))
-            }
-
-            currentDate = currentDate.plusDays(1)
-        }
-
-        return result
     }
 
     private suspend fun readSleepData(


### PR DESCRIPTION
Replaces the per-calendar-day aggregate read with a raw readRecords call so each StepsRecord (1-15 min granularity from the phone pedometer) reaches the webhook receiver with its own start_time. This lets a downstream consumer bucket by any logical-day boundary (e.g. day_start_hour=4) without losing the early-morning portion of a calendar day to the wrong bucket.

## Summary
- Briefly describe what changed and why.

## Related
- Closes #
- Related to #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Build/CI change

## Checklist
- [ ] I tested this change locally
- [ ] I updated documentation (if needed)
- [ ] I added/updated tests (if needed)
- [ ] I verified there are no breaking changes
- [ ] I checked for sensitive data/secrets

## Screenshots / Recordings (if UI changes)
- N/A

## Additional notes
- N/A
