### PR TITLE
Implement fallback mechanisms for distance aggregation and health summation

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -747,7 +747,9 @@ class HealthConnectManager(private val context: Context) {
     }
 
     private suspend fun readDistanceData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<DistanceData> {
-        // Aggregate distance per calendar day (same pattern as steps)
+        // Aggregate distance per calendar day (same pattern as steps).
+        // If the aggregate returns null (e.g., Google Health/Fit data after the Fitbit rebrand),
+        // fall back to summing raw DistanceRecord entries so distance is never silently omitted.
         val zone = java.time.ZoneId.systemDefault()
         val result = mutableListOf<DistanceData>()
 
@@ -767,12 +769,23 @@ class HealthConnectManager(private val context: Context) {
                 continue
             }
 
-            val request = AggregateRequest(
+            val aggregateRequest = AggregateRequest(
                 metrics = setOf(DistanceRecord.DISTANCE_TOTAL),
                 timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
             )
-            val response = healthConnectClient.aggregate(request)
-            val dayDistance = response[DistanceRecord.DISTANCE_TOTAL]?.inMeters ?: 0.0
+            val aggregateResponse = healthConnectClient.aggregate(aggregateRequest)
+            val aggregateMeters = aggregateResponse[DistanceRecord.DISTANCE_TOTAL]?.inMeters
+
+            val dayDistance: Double = if (aggregateMeters != null && aggregateMeters > 0.0) {
+                aggregateMeters
+            } else {
+                // Aggregate returned null or zero — fall back to raw records.
+                val rawRequest = ReadRecordsRequest(
+                    recordType = DistanceRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
+                )
+                readAllRecords(rawRequest).sumOf { it.distance.inMeters }
+            }
 
             if (dayDistance > 0.0) {
                 result.add(DistanceData(

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -673,12 +673,23 @@ class HealthConnectManager(private val context: Context) {
                 continue
             }
 
-            val request = AggregateRequest(
+            val aggregateRequest = AggregateRequest(
                 metrics = setOf(StepsRecord.COUNT_TOTAL),
                 timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
             )
-            val response = healthConnectClient.aggregate(request)
-            val daySteps = response[StepsRecord.COUNT_TOTAL] ?: 0L
+            val aggregateResponse = healthConnectClient.aggregate(aggregateRequest)
+            val aggregateSteps = aggregateResponse[StepsRecord.COUNT_TOTAL]
+
+            val daySteps: Long = if (aggregateSteps != null && aggregateSteps > 0L) {
+                aggregateSteps
+            } else {
+                // Aggregate returned null — fall back to summing raw records.
+                val rawRequest = ReadRecordsRequest(
+                    recordType = StepsRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
+                )
+                readAllRecords(rawRequest).sumOf { it.count }
+            }
 
             if (daySteps > 0) {
                 result.add(StepsData(
@@ -822,12 +833,23 @@ class HealthConnectManager(private val context: Context) {
                 continue
             }
 
-            val request = AggregateRequest(
+            val aggregateRequest = AggregateRequest(
                 metrics = setOf(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL),
                 timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
             )
-            val response = healthConnectClient.aggregate(request)
-            val dayCalories = response[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories ?: 0.0
+            val aggregateResponse = healthConnectClient.aggregate(aggregateRequest)
+            val aggregateKcal = aggregateResponse[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories
+
+            val dayCalories: Double = if (aggregateKcal != null && aggregateKcal > 0.0) {
+                aggregateKcal
+            } else {
+                // Aggregate returned null — fall back to summing raw records.
+                val rawRequest = ReadRecordsRequest(
+                    recordType = ActiveCaloriesBurnedRecord::class,
+                    timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
+                )
+                readAllRecords(rawRequest).sumOf { it.energy.inKilocalories }
+            }
 
             if (dayCalories > 0.0) {
                 result.add(ActiveCaloriesData(

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -260,13 +260,29 @@ class SyncManager(private val context: Context) {
                 data.vo2Max.isEmpty() && data.boneMass.isEmpty()
     }
 
+    /**
+     * Returns the epoch-millisecond value of the latest endTime that is NOT
+     * in the future, or null if every endTime is in the future.
+     *
+     * Clamping to now() prevents future-dated projection records (e.g., Google
+     * Health's daily calorie/distance projection ending at local midnight) from
+     * advancing the per-type lastSync cursor past wall-clock time. Without this
+     * clamp, all genuinely-closed records produced after the first sync are
+     * filtered out by the endTime >= lastSync guard in each readXxx function.
+     */
+    private fun clampedMaxEndMs(endTimes: Sequence<Instant>, now: Instant): Long? =
+        endTimes.filter { !it.isAfter(now) }.maxOrNull()?.toEpochMilli()
+
     private fun updateSyncTimestamps(data: HealthData, syncCounts: MutableMap<HealthDataType, Int>) {
+        val now = Instant.now()
         if (data.steps.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.STEPS, data.steps.maxOf { it.endTime }.toEpochMilli())
+            clampedMaxEndMs(data.steps.asSequence().map { it.endTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.STEPS, it) }
             syncCounts[HealthDataType.STEPS] = data.steps.size
         }
         if (data.sleep.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.SLEEP, data.sleep.maxOf { it.sessionEndTime }.toEpochMilli())
+            clampedMaxEndMs(data.sleep.asSequence().map { it.sessionEndTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.SLEEP, it) }
             syncCounts[HealthDataType.SLEEP] = data.sleep.size
         }
         if (data.heartRate.isNotEmpty()) {
@@ -278,15 +294,21 @@ class SyncManager(private val context: Context) {
             syncCounts[HealthDataType.HEART_RATE_VARIABILITY] = data.heartRateVariability.size
         }
         if (data.distance.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.DISTANCE, data.distance.maxOf { it.endTime }.toEpochMilli())
+            clampedMaxEndMs(data.distance.asSequence().map { it.endTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.DISTANCE, it) }
             syncCounts[HealthDataType.DISTANCE] = data.distance.size
         }
         if (data.activeCalories.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.ACTIVE_CALORIES, data.activeCalories.maxOf { it.endTime }.toEpochMilli())
+            clampedMaxEndMs(data.activeCalories.asSequence().map { it.endTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.ACTIVE_CALORIES, it) }
             syncCounts[HealthDataType.ACTIVE_CALORIES] = data.activeCalories.size
         }
         if (data.totalCalories.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.TOTAL_CALORIES, data.totalCalories.maxOf { it.endTime }.toEpochMilli())
+            // Clamp to now() so a future-dated endTime (e.g., daily projection
+            // from Google Health ending at local midnight) cannot advance the
+            // cursor past wall-clock time and starve subsequent closed records.
+            clampedMaxEndMs(data.totalCalories.asSequence().map { it.endTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.TOTAL_CALORIES, it) }
             syncCounts[HealthDataType.TOTAL_CALORIES] = data.totalCalories.size
         }
         if (data.weight.isNotEmpty()) {
@@ -326,15 +348,18 @@ class SyncManager(private val context: Context) {
             syncCounts[HealthDataType.RESTING_HEART_RATE] = data.restingHeartRate.size
         }
         if (data.exercise.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.EXERCISE, data.exercise.maxOf { it.endTime }.toEpochMilli())
+            clampedMaxEndMs(data.exercise.asSequence().map { it.endTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.EXERCISE, it) }
             syncCounts[HealthDataType.EXERCISE] = data.exercise.size
         }
         if (data.hydration.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.HYDRATION, data.hydration.maxOf { it.endTime }.toEpochMilli())
+            clampedMaxEndMs(data.hydration.asSequence().map { it.endTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.HYDRATION, it) }
             syncCounts[HealthDataType.HYDRATION] = data.hydration.size
         }
         if (data.nutrition.isNotEmpty()) {
-            preferencesManager.setLastSyncTimestamp(HealthDataType.NUTRITION, data.nutrition.maxOf { it.endTime }.toEpochMilli())
+            clampedMaxEndMs(data.nutrition.asSequence().map { it.endTime }, now)
+                ?.let { preferencesManager.setLastSyncTimestamp(HealthDataType.NUTRITION, it) }
             syncCounts[HealthDataType.NUTRITION] = data.nutrition.size
         }
         if (data.basalMetabolicRate.isNotEmpty()) {


### PR DESCRIPTION
## Summary

Two related bugs caused health data to be silently dropped from webhook payloads, both triggered by Google Health's new behaviour after the Fitbit rebrand (May 2026):

**Bug 1 — Future-dated endTime poisons the lastSync cursor (closes #40)**
Google Health writes interval records (e.g. `TotalCaloriesBurnedRecord`) with `endTime` set to local midnight — a future timestamp. `updateSyncTimestamps()` was calling `maxOf { it.endTime }` on these records, advancing the per-type cursor to midnight. Every subsequent sync then filtered out all genuinely-closed records for the rest of the day because their `endTime < midnight`.

Fix: added a `clampedMaxEndMs()` helper in `SyncManager` that filters out future-dated `endTime` values before taking the max. Applied to all interval-based types: `steps`, `sleep`, `distance`, `activeCalories`, `totalCalories`, `exercise`, `hydration`, `nutrition`.

**Bug 2 — Null aggregate silently drops data (closes #38)**
`readDistanceData()`, `readStepsData()`, and `readActiveCaloriesData()` all used `AggregateRequest` as the sole read path. When `AggregateRequest` returns `null` for a given day (observed with Google Fit/Health data), the `?: 0` elvis quietly treated it as zero and skipped the day entirely — even though raw records exist and are visible in Health Connect Toolbox.

Fix: when the aggregate result is `null` or `0`, each function now falls back to a `ReadRecordsRequest` and sums the raw records directly, matching what Health Connect actually stores.

## Related
- Closes #40
- Closes #38

## Type of change
- [x] Bug fix

## Checklist
- [ ] I tested this change locally
- [ ] I updated documentation (if needed)
- [ ] I added/updated tests (if needed)
- [x] I verified there are no breaking changes
- [x] I checked for sensitive data/secrets

## Screenshots / Recordings (if UI changes)
- N/A

## Additional notes
- Point-in-time record types (`heartRate`, `weight`, `bloodPressure`, etc.) are unaffected — they use `time` not `endTime`, so the cursor clamp does not apply.
- Dashboard aggregate helpers (`aggregateSteps`, `aggregateDistanceMeters`, `aggregateActiveCalories`) intentionally keep their `?: 0` fallback since they are display-only and have no impact on sync cursors or webhook payloads.
