### PR TITLE
fix: stop manual sync requiring ungrantable Health Connect permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <!-- Health Connect Permissions -->
     <uses-permission android:name="android.permission.health.READ_STEPS" />
+    <uses-permission android:name="android.permission.health.READ_STEPS_CADENCE" />
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
     <uses-permission android:name="android.permission.health.READ_DISTANCE" />

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -1130,16 +1130,20 @@ class HealthConnectManager(private val context: Context) {
 
         fun getPermissionsForTypes(
             types: Set<HealthDataType>,
-            includeBackgroundPermission: Boolean = true
+            includeBackgroundPermission: Boolean = true,
+            includeHistoryPermission: Boolean = true,
+            includeStepsCadence: Boolean = true
         ): Set<String> {
             val permissions = types.map { HealthPermission.getReadPermission(it.recordClass) }.toMutableSet()
-            if (HealthDataType.STEPS in types) {
+            if (includeStepsCadence && HealthDataType.STEPS in types) {
                 permissions.add(HealthPermission.getReadPermission(StepsCadenceRecord::class))
             }
             if (includeBackgroundPermission) {
                 permissions.add(BACKGROUND_PERMISSION_STR)
             }
-            permissions.add("android.permission.health.READ_HEALTH_DATA_HISTORY")
+            if (includeHistoryPermission) {
+                permissions.add("android.permission.health.READ_HEALTH_DATA_HISTORY")
+            }
             return permissions
         }
 

--- a/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
+++ b/app/src/main/java/com/hcwebhook/app/components/ManualSyncCard.kt
@@ -147,7 +147,15 @@ fun ManualSyncCard(onSyncCompleted: () -> Unit = {}) {
                                 val enabledTypes = preferencesManager.getEnabledDataTypes()
                                 val requiredPermissions = HealthConnectManager.getPermissionsForTypes(
                                     enabledTypes,
-                                    includeBackgroundPermission = false
+                                    includeBackgroundPermission = false,
+                                    // The manual-sync gate should only require read access to the
+                                    // enabled data types. READ_HEALTH_DATA_HISTORY is only needed for
+                                    // ranges older than 30 days, and READ_STEPS_CADENCE is optional
+                                    // (its aggregate read is already try/catch-guarded). Requiring
+                                    // either here left users stuck on "Permissions required for sync"
+                                    // with no in-app way to grant them.
+                                    includeHistoryPermission = false,
+                                    includeStepsCadence = false
                                 )
                                 if (requiredPermissions.isNotEmpty() && !healthConnectManager.hasPermissions(requiredPermissions)) {
                                     syncMessage = context.getString(R.string.err_permissions_required)


### PR DESCRIPTION
# fix: stop manual sync requiring ungrantable Health Connect permissions

Fixes #43.

### Problem

The manual-sync pre-flight gate (`ManualSyncCard`) calls `getPermissionsForTypes()`, which always added `READ_HEALTH_DATA_HISTORY` and, when Steps was enabled, `READ_STEPS_CADENCE`. Both produce an unrecoverable **"Permissions required for sync."**:

- **`READ_STEPS_CADENCE`** is never declared in `AndroidManifest.xml`, so Health Connect can never grant it → any sync with **Steps** enabled fails forever.
- **`READ_HEALTH_DATA_HISTORY`** is only requested when a data-type permission is *also* missing (`ConfigurationScreen`), so once every enabled type is granted there is no in-app way to grant history → sync stays blocked even though the "N of N permissions granted" card (which never counts history) shows all green.

### Change

- Declare `READ_STEPS_CADENCE` in the manifest so cadence is grantable (its aggregate read is already `try/catch`-guarded, so it remains optional).
- Add `includeHistoryPermission` / `includeStepsCadence` flags to `getPermissionsForTypes` (default `true`, so existing callers are unchanged) and pass both `false` from the manual-sync gate. The gate now only requires read access to the **enabled data types** — which is all that's needed to read recent data.

3 files, +17/−4. No behavior change for any other caller of `getPermissionsForTypes`.

### Why this is safe

- Recent / "new data only" reads do not need `READ_HEALTH_DATA_HISTORY` (it only governs data older than 30 days).
- `readStepsCadenceMetrics()` already swallows failures and returns empty metrics, so dropping the hard cadence requirement degrades gracefully on providers that don't expose cadence.

### Testing

- `./gradlew :app:assembleFossDebug` → BUILD SUCCESSFUL.
- Verified the resulting APK declares `READ_STEPS_CADENCE` (`aapt2 dump permissions`).
- Manual sync with only a single data type enabled (e.g. Hydration) and with Steps enabled now passes the gate and proceeds to sync instead of aborting.

### Follow-ups (not in this PR)

- Make the "permissions granted" indicator include history/background/cadence so it isn't misleading.
- Add a dedicated request path for `READ_HEALTH_DATA_HISTORY` so users who want >30-day historical sync can grant it explicitly.
