### PR TITLE
feat: option to send raw step intervals instead of daily cumulative

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -286,7 +286,8 @@ class HealthConnectManager(private val context: Context) {
         lastSyncTimestamps: Map<HealthDataType, Instant?>,
         timeRangeDays: Int? = null,
         start: Instant? = null,
-        end: Instant? = null
+        end: Instant? = null,
+        rawSteps: Boolean = false
     ): Result<HealthData> {
         return try {
             val endTime = end ?: Instant.now()
@@ -301,7 +302,7 @@ class HealthConnectManager(private val context: Context) {
             }
 
             val stepsData = if (HealthDataType.STEPS in enabledTypes)
-                readStepsData(startTime, endTime, lastSyncTimestamps[HealthDataType.STEPS]) else emptyList()
+                readStepsData(startTime, endTime, lastSyncTimestamps[HealthDataType.STEPS], rawSteps) else emptyList()
             val sleepData = if (HealthDataType.SLEEP in enabledTypes)
                 readSleepData(startTime, endTime, lastSyncTimestamps[HealthDataType.SLEEP]) else emptyList()
             val heartRateData = if (HealthDataType.HEART_RATE in enabledTypes)
@@ -647,6 +648,47 @@ class HealthConnectManager(private val context: Context) {
     private suspend fun readStepsData(
         startTime: Instant,
         endTime: Instant,
+        lastSync: Instant?,
+        rawIntervals: Boolean
+    ): List<StepsData> {
+        return if (rawIntervals) {
+            readRawStepsData(startTime, endTime, lastSync)
+        } else {
+            readDailyStepsData(startTime, endTime, lastSync)
+        }
+    }
+
+    private suspend fun readRawStepsData(
+        startTime: Instant,
+        endTime: Instant,
+        lastSync: Instant?
+    ): List<StepsData> {
+        // Emit raw step records as-is (one StepsData per Health Connect interval)
+        // instead of collapsing them into a single per-day cumulative total.
+        // Health Connect stores steps in small intervals; we forward those
+        // intervals directly so the server receives granular, non-cumulative data.
+        val request = ReadRecordsRequest(
+            recordType = StepsRecord::class,
+            timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
+        )
+
+        return readAllRecords(request)
+            .filter { record ->
+                lastSync == null || record.endTime >= lastSync
+            }
+            .filter { it.count > 0 }
+            .map { record ->
+                StepsData(
+                    count = record.count,
+                    startTime = record.startTime,
+                    endTime = record.endTime
+                )
+            }
+    }
+
+    private suspend fun readDailyStepsData(
+        startTime: Instant,
+        endTime: Instant,
         lastSync: Instant?
     ): List<StepsData> {
         // Aggregate steps per calendar day (using device timezone) instead of
@@ -683,7 +725,7 @@ class HealthConnectManager(private val context: Context) {
             val daySteps: Long = if (aggregateSteps != null && aggregateSteps > 0L) {
                 aggregateSteps
             } else {
-                // Aggregate returned null — fall back to summing raw records.
+                // Aggregate returned null, fall back to summing raw records.
                 val rawRequest = ReadRecordsRequest(
                     recordType = StepsRecord::class,
                     timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)

--- a/app/src/main/java/com/hcwebhook/app/PreferencesManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/PreferencesManager.kt
@@ -44,6 +44,7 @@ class PreferencesManager(context: Context) {
         private const val KEY_LOCAL_HTTP_AUTH_ENABLED = "local_http_auth_enabled"
         private const val KEY_LOCAL_HTTP_TOKEN = "local_http_token"
         private const val KEY_NOTIFICATION_CONFIGS = "notification_configs"
+        private const val KEY_RAW_STEPS_ENABLED = "raw_steps_enabled"
     }
 
 
@@ -348,6 +349,17 @@ class PreferencesManager(context: Context) {
         prefs.edit().putString(KEY_NOTIFICATION_CONFIGS, configsJson).apply()
     }
 
+    /**
+     * When enabled, step data is sent as raw Health Connect intervals (granular,
+     * non-cumulative) instead of a single per-day cumulative total.
+     * Defaults to false to preserve the existing per-day aggregate behavior.
+     */
+    fun isRawStepsEnabled(): Boolean = prefs.getBoolean(KEY_RAW_STEPS_ENABLED, false)
+
+    fun setRawStepsEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_RAW_STEPS_ENABLED, enabled).apply()
+    }
+
     // -------------------------------------------------------------------------
     // Export / Import
     // -------------------------------------------------------------------------
@@ -365,7 +377,8 @@ class PreferencesManager(context: Context) {
             scheduledSyncs = getScheduledSyncs(),
             localTcpEnabled = isLocalTcpEnabled(),
             localTcpPort = getLocalTcpPort(),
-            notificationConfigs = getNotificationConfigs()
+            notificationConfigs = getNotificationConfigs(),
+            rawStepsEnabled = isRawStepsEnabled()
         )
     }
 
@@ -388,5 +401,6 @@ class PreferencesManager(context: Context) {
         setLocalTcpEnabled(export.localTcpEnabled)
         setLocalTcpPort(export.localTcpPort)
         setNotificationConfigs(export.notificationConfigs)
+        setRawStepsEnabled(export.rawStepsEnabled)
     }
 }

--- a/app/src/main/java/com/hcwebhook/app/SettingsExport.kt
+++ b/app/src/main/java/com/hcwebhook/app/SettingsExport.kt
@@ -16,5 +16,6 @@ data class SettingsExport(
     val scheduledSyncs: List<ScheduledSync> = emptyList(),
     val localTcpEnabled: Boolean = false,
     val localTcpPort: Int = 8787,
-    val notificationConfigs: List<NotificationConfig> = emptyList()
+    val notificationConfigs: List<NotificationConfig> = emptyList(),
+    val rawStepsEnabled: Boolean = false
 )

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -43,7 +43,8 @@ class SyncManager(private val context: Context) {
                 lastSyncTimestamps = emptyMap(),
                 timeRangeDays = timeRangeDays,
                 start = start,
-                end = end
+                end = end,
+                rawSteps = preferencesManager.isRawStepsEnabled()
             )
             if (healthDataResult.isFailure) {
                 return@withContext Result.failure(
@@ -100,7 +101,8 @@ class SyncManager(private val context: Context) {
                 lastSyncTimestamps = lastSyncTimestamps,
                 timeRangeDays = timeRangeDays,
                 start = start,
-                end = end
+                end = end,
+                rawSteps = preferencesManager.isRawStepsEnabled()
             )
             if (healthDataResult.isFailure) {
                 return@withContext Result.failure(healthDataResult.exceptionOrNull() ?: Exception("Failed to read health data"))

--- a/app/src/main/java/com/hcwebhook/app/screens/ConfigurationScreen.kt
+++ b/app/src/main/java/com/hcwebhook/app/screens/ConfigurationScreen.kt
@@ -75,6 +75,7 @@ fun ConfigurationScreen(
     var syncInterval by remember { mutableStateOf(preferencesManager.getSyncIntervalMinutes().toString()) }
     var scheduledSyncs by remember { mutableStateOf(preferencesManager.getScheduledSyncs()) }
     var enabledDataTypes by remember { mutableStateOf(preferencesManager.getEnabledDataTypes()) }
+    var rawStepsEnabled by remember { mutableStateOf(preferencesManager.isRawStepsEnabled()) }
 
     var showDataTypesSheet by remember { mutableStateOf(false) }
     var showPermissionsSheet by remember { mutableStateOf(false) }
@@ -445,6 +446,52 @@ fun ConfigurationScreen(
                             try { permissionLauncher.launch(setOf(HealthConnectManager.BACKGROUND_PERMISSION_STR)) } catch (e: Exception) { Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_LONG).show() }
                         }, modifier = Modifier.fillMaxWidth()) {
                             Text(stringResource(R.string.config_action_grant_bg))
+                        }
+                    }
+                }
+            }
+
+            // ── Steps format ──────────────────────────────────────────────────
+            if (HealthDataType.STEPS in enabledDataTypes) {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = iconForDataType(HealthDataType.STEPS),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                stringResource(R.string.config_steps_format_title),
+                                style = MaterialTheme.typography.titleSmall
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Text(
+                            stringResource(R.string.config_steps_format_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                stringResource(R.string.config_steps_format_toggle),
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Switch(
+                                checked = rawStepsEnabled,
+                                onCheckedChange = { checked ->
+                                    rawStepsEnabled = checked
+                                    preferencesManager.setRawStepsEnabled(checked)
+                                }
+                            )
                         }
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,9 @@
     <string name="config_toast_interval_saved">Interval saved</string>
     <string name="config_toast_min_interval">Min 15 minutes</string>
     <string name="config_action_add_schedule">Add Schedule Time</string>
+    <string name="config_steps_format_title">Steps Format</string>
+    <string name="config_steps_format_desc">Send raw step intervals instead of a single daily cumulative total. Useful when your server expects granular, non-cumulative data.</string>
+    <string name="config_steps_format_toggle">Raw step intervals</string>
     <string name="config_bg_perm_title">Background Permission Required</string>
     <string name="config_bg_perm_desc">To sync data automatically on a schedule or interval, you must grant Health Connect access for background use.</string>
     <string name="config_action_grant_bg">Grant Background Permission</string>


### PR DESCRIPTION
## Summary
Step data is currently always aggregated into a single per-day cumulative total before being sent to webhooks. Some servers expect granular, non-cumulative data that matches how Health Connect actually stores steps (in small intervals throughout the day).

This PR adds an opt-in **"Raw step intervals"** toggle. When enabled, each Health Connect `StepsRecord` interval is forwarded as its own record (`count` / `start_time` / `end_time`). When disabled, the existing per-day aggregate behavior is preserved.

The setting:
- Lives on the Configuration screen, shown only when **Steps** is enabled.
- Is persisted in `PreferencesManager` (`raw_steps_enabled`).
- Defaults to **off**, so existing setups are completely unaffected.
- Is included in settings export/import.

### How it works
`readStepsData` now branches on the flag:
- `readRawStepsData` reads raw `StepsRecord`s via `readAllRecords` (with pagination), filters by `lastSync` and `count > 0`, and maps each interval to a `StepsData`.
- `readDailyStepsData` is the original per-day aggregate logic, unchanged.

The webhook JSON serialization already iterates the steps list, so no payload-building changes were needed; the array simply contains multiple interval records instead of one daily record.

## Related
- Closes #
- Related to #

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Build/CI change

## Checklist
- [x] I tested this change locally
- [ ] I updated documentation (if needed)
- [ ] I added/updated tests (if needed)
- [x] I verified there are no breaking changes
- [x] I checked for sensitive data/secrets

## Screenshots / Recordings (if UI changes)
- A "Steps Format" card with a "Raw step intervals" switch appears on the Configuration screen when Steps is enabled.

## Additional notes
- Default behavior is unchanged (toggle defaults to off).
- Verified locally with `./gradlew assembleFossDebug` (BUILD SUCCESSFUL). This confirms it compiles and packages; I did not run a full on-device/emulator runtime test.
