### PR TITLE
Include record metadata (data origin / recording method / device) on exercise sessions

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -156,7 +156,8 @@ data class StepsData(
 data class SleepData(
     val sessionEndTime: Instant,
     val duration: Duration,
-    val stages: List<SleepStage>
+    val stages: List<SleepStage>,
+    val metadata: RecordMetadata? = null
 )
 
 data class SleepStage(
@@ -168,12 +169,14 @@ data class SleepStage(
 
 data class HeartRateData(
     val bpm: Long,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class HeartRateVariabilityData(
     val rmssdMillis: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class DistanceData(
@@ -191,55 +194,65 @@ data class ActiveCaloriesData(
 data class TotalCaloriesData(
     val calories: Double,
     val startTime: Instant,
-    val endTime: Instant
+    val endTime: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class WeightData(
     val kilograms: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class HeightData(
     val meters: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class BloodPressureData(
     val systolic: Double,
     val diastolic: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class BloodGlucoseData(
     val mmolPerLiter: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class OxygenSaturationData(
     val percentage: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class BodyTemperatureData(
     val celsius: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class SkinTemperatureData(
     val time: Instant,
     val deltaCelsius: Double,
     val baselineCelsius: Double?,
-    val measurementLocation: Int
+    val measurementLocation: Int,
+    val metadata: RecordMetadata? = null
 )
 
 data class RespiratoryRateData(
     val rate: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class RestingHeartRateData(
     val bpm: Long,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class ExerciseData(
@@ -258,7 +271,8 @@ data class ExerciseData(
 data class HydrationData(
     val liters: Double,
     val startTime: Instant,
-    val endTime: Instant
+    val endTime: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class NutritionData(
@@ -271,32 +285,38 @@ data class NutritionData(
     val dietaryFiber: Double?,
     val name: String?,
     val startTime: Instant,
-    val endTime: Instant
+    val endTime: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class BasalMetabolicRateData(
     val watts: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class BodyFatData(
     val percentage: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class LeanBodyMassData(
     val kilograms: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class Vo2MaxData(
     val mlPerKgPerMin: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class BoneMassData(
     val kilograms: Double,
-    val time: Instant
+    val time: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 class HealthConnectManager(private val context: Context) {
@@ -762,7 +782,8 @@ class HealthConnectManager(private val context: Context) {
                 SleepData(
                     sessionEndTime = record.endTime,
                     duration = Duration.between(record.startTime, record.endTime),
-                    stages = stages
+                    stages = stages,
+                    metadata = record.metadata.toRecordMetadata()
                 )
             }
     }
@@ -774,7 +795,7 @@ class HealthConnectManager(private val context: Context) {
             .flatMap { record ->
                 record.samples
                     .filter { lastSync == null || it.time >= lastSync }
-                    .map { HeartRateData(it.beatsPerMinute, it.time) }
+                    .map { HeartRateData(it.beatsPerMinute, it.time, record.metadata.toRecordMetadata()) }
             }
     }
 
@@ -782,7 +803,7 @@ class HealthConnectManager(private val context: Context) {
         val request = ReadRecordsRequest(recordType = HeartRateVariabilityRmssdRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { HeartRateVariabilityData(it.heartRateVariabilityMillis, it.time) }
+            .map { HeartRateVariabilityData(it.heartRateVariabilityMillis, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readDistanceData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<DistanceData> {
@@ -897,49 +918,49 @@ class HealthConnectManager(private val context: Context) {
         val request = ReadRecordsRequest(recordType = TotalCaloriesBurnedRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.endTime >= lastSync }
-            .map { TotalCaloriesData(it.energy.inKilocalories, it.startTime, it.endTime) }
+            .map { TotalCaloriesData(it.energy.inKilocalories, it.startTime, it.endTime, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readWeightData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<WeightData> {
         val request = ReadRecordsRequest(recordType = WeightRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { WeightData(it.weight.inKilograms, it.time) }
+            .map { WeightData(it.weight.inKilograms, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readHeightData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<HeightData> {
         val request = ReadRecordsRequest(recordType = HeightRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { HeightData(it.height.inMeters, it.time) }
+            .map { HeightData(it.height.inMeters, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBloodPressureData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BloodPressureData> {
         val request = ReadRecordsRequest(recordType = BloodPressureRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { BloodPressureData(it.systolic.inMillimetersOfMercury, it.diastolic.inMillimetersOfMercury, it.time) }
+            .map { BloodPressureData(it.systolic.inMillimetersOfMercury, it.diastolic.inMillimetersOfMercury, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBloodGlucoseData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BloodGlucoseData> {
         val request = ReadRecordsRequest(recordType = BloodGlucoseRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { BloodGlucoseData(it.level.inMillimolesPerLiter, it.time) }
+            .map { BloodGlucoseData(it.level.inMillimolesPerLiter, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readOxygenSaturationData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<OxygenSaturationData> {
         val request = ReadRecordsRequest(recordType = OxygenSaturationRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { OxygenSaturationData(it.percentage.value, it.time) }
+            .map { OxygenSaturationData(it.percentage.value, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBodyTemperatureData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BodyTemperatureData> {
         val request = ReadRecordsRequest(recordType = BodyTemperatureRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { BodyTemperatureData(it.temperature.inCelsius, it.time) }
+            .map { BodyTemperatureData(it.temperature.inCelsius, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readSkinTemperatureData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<SkinTemperatureData> {
@@ -953,7 +974,8 @@ class HealthConnectManager(private val context: Context) {
                         time = delta.time,
                         deltaCelsius = delta.delta.inCelsius,
                         baselineCelsius = record.baseline?.inCelsius,
-                        measurementLocation = record.measurementLocation
+                        measurementLocation = record.measurementLocation,
+                        metadata = record.metadata.toRecordMetadata()
                     )
                 }
         }
@@ -963,14 +985,14 @@ class HealthConnectManager(private val context: Context) {
         val request = ReadRecordsRequest(recordType = RespiratoryRateRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { RespiratoryRateData(it.rate, it.time) }
+            .map { RespiratoryRateData(it.rate, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readRestingHeartRateData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<RestingHeartRateData> {
         val request = ReadRecordsRequest(recordType = RestingHeartRateRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { RestingHeartRateData(it.beatsPerMinute, it.time) }
+            .map { RestingHeartRateData(it.beatsPerMinute, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readExerciseData(
@@ -1079,7 +1101,7 @@ class HealthConnectManager(private val context: Context) {
         val request = ReadRecordsRequest(recordType = HydrationRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.endTime >= lastSync }
-            .map { HydrationData(it.volume.inLiters, it.startTime, it.endTime) }
+            .map { HydrationData(it.volume.inLiters, it.startTime, it.endTime, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readNutritionData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<NutritionData> {
@@ -1097,7 +1119,8 @@ class HealthConnectManager(private val context: Context) {
                     dietaryFiber = it.dietaryFiber?.inGrams,
                     name = it.name,
                     startTime = it.startTime,
-                    endTime = it.endTime
+                    endTime = it.endTime,
+                    metadata = it.metadata.toRecordMetadata()
                 )
             }
     }
@@ -1106,35 +1129,35 @@ class HealthConnectManager(private val context: Context) {
         val request = ReadRecordsRequest(recordType = BasalMetabolicRateRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { BasalMetabolicRateData(it.basalMetabolicRate.inWatts, it.time) }
+            .map { BasalMetabolicRateData(it.basalMetabolicRate.inWatts, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBodyFatData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BodyFatData> {
         val request = ReadRecordsRequest(recordType = BodyFatRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { BodyFatData(it.percentage.value, it.time) }
+            .map { BodyFatData(it.percentage.value, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readLeanBodyMassData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<LeanBodyMassData> {
         val request = ReadRecordsRequest(recordType = LeanBodyMassRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { LeanBodyMassData(it.mass.inKilograms, it.time) }
+            .map { LeanBodyMassData(it.mass.inKilograms, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readVo2MaxData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<Vo2MaxData> {
         val request = ReadRecordsRequest(recordType = Vo2MaxRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { Vo2MaxData(it.vo2MillilitersPerMinuteKilogram, it.time) }
+            .map { Vo2MaxData(it.vo2MillilitersPerMinuteKilogram, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBoneMassData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BoneMassData> {
         val request = ReadRecordsRequest(recordType = BoneMassRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
         return response.filter { lastSync == null || it.time >= lastSync }
-            .map { BoneMassData(it.mass.inKilograms, it.time) }
+            .map { BoneMassData(it.mass.inKilograms, it.time, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun <T : Record> readAllRecords(request: ReadRecordsRequest<T>): List<T> {

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -5,6 +5,7 @@ import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
 import kotlinx.coroutines.CancellationException
 import androidx.health.connect.client.records.*
+import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
@@ -120,6 +121,32 @@ data class HealthData(
     val boneMass: List<BoneMassData>
 )
 
+/**
+ * Provenance of a Health Connect record: which app wrote it, how it was recorded, and on what
+ * device. Lets downstream consumers tell e.g. an automatically-detected session apart from one
+ * recorded by gym equipment, and deduplicate records that arrive from multiple source apps.
+ */
+data class RecordMetadata(
+    val dataOrigin: String,
+    val recordingMethod: String,
+    val deviceManufacturer: String? = null,
+    val deviceModel: String? = null,
+    val deviceType: Int? = null
+)
+
+fun Metadata.toRecordMetadata(): RecordMetadata = RecordMetadata(
+    dataOrigin = dataOrigin.packageName,
+    recordingMethod = when (recordingMethod) {
+        Metadata.RECORDING_METHOD_ACTIVELY_RECORDED -> "actively_recorded"
+        Metadata.RECORDING_METHOD_AUTOMATICALLY_RECORDED -> "automatically_recorded"
+        Metadata.RECORDING_METHOD_MANUAL_ENTRY -> "manual_entry"
+        else -> "unknown"
+    },
+    deviceManufacturer = device?.manufacturer,
+    deviceModel = device?.model,
+    deviceType = device?.type,
+)
+
 data class StepsData(
     val count: Long,
     val startTime: Instant,
@@ -224,7 +251,8 @@ data class ExerciseData(
     val steps: Long? = null,
     val avgCadenceSpm: Double? = null,
     val maxCadenceSpm: Double? = null,
-    val strideLengthMeters: Double? = null
+    val strideLengthMeters: Double? = null,
+    val metadata: RecordMetadata? = null
 )
 
 data class HydrationData(
@@ -969,7 +997,8 @@ class HealthConnectManager(private val context: Context) {
                     steps = steps,
                     avgCadenceSpm = cadenceMetrics.avg ?: deriveAverageCadenceSpm(steps, duration),
                     maxCadenceSpm = cadenceMetrics.max,
-                    strideLengthMeters = deriveStrideLengthMeters(distanceMeters, steps)
+                    strideLengthMeters = deriveStrideLengthMeters(distanceMeters, steps),
+                    metadata = it.metadata.toRecordMetadata()
                 )
             }
     }

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -468,6 +468,7 @@ class SyncManager(private val context: Context) {
                                     })
                                 }
                             }
+                            sleep.metadata?.let { meta -> putRecordMetadata(meta) }
                         })
                     }
                 }
@@ -478,6 +479,7 @@ class SyncManager(private val context: Context) {
                     healthData.heartRate.forEach { add(buildJsonObject {
                         put("bpm", it.bpm)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -487,6 +489,7 @@ class SyncManager(private val context: Context) {
                     healthData.heartRateVariability.forEach { add(buildJsonObject {
                         put("rmssd_millis", it.rmssdMillis)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -517,6 +520,7 @@ class SyncManager(private val context: Context) {
                         put("calories", it.calories)
                         put("start_time", it.startTime.toString())
                         put("end_time", it.endTime.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -526,6 +530,7 @@ class SyncManager(private val context: Context) {
                     healthData.weight.forEach { add(buildJsonObject {
                         put("kilograms", it.kilograms)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -535,6 +540,7 @@ class SyncManager(private val context: Context) {
                     healthData.height.forEach { add(buildJsonObject {
                         put("meters", it.meters)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -545,6 +551,7 @@ class SyncManager(private val context: Context) {
                         put("systolic", it.systolic)
                         put("diastolic", it.diastolic)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -554,6 +561,7 @@ class SyncManager(private val context: Context) {
                     healthData.bloodGlucose.forEach { add(buildJsonObject {
                         put("mmol_per_liter", it.mmolPerLiter)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -563,6 +571,7 @@ class SyncManager(private val context: Context) {
                     healthData.oxygenSaturation.forEach { add(buildJsonObject {
                         put("percentage", it.percentage)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -572,6 +581,7 @@ class SyncManager(private val context: Context) {
                     healthData.bodyTemperature.forEach { add(buildJsonObject {
                         put("celsius", it.celsius)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -583,6 +593,7 @@ class SyncManager(private val context: Context) {
                         put("delta_celsius", it.deltaCelsius)
                         it.baselineCelsius?.let { baseline -> put("baseline_celsius", baseline) }
                         put("measurement_location", it.measurementLocation)
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -592,6 +603,7 @@ class SyncManager(private val context: Context) {
                     healthData.respiratoryRate.forEach { add(buildJsonObject {
                         put("rate", it.rate)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -601,6 +613,7 @@ class SyncManager(private val context: Context) {
                     healthData.restingHeartRate.forEach { add(buildJsonObject {
                         put("bpm", it.bpm)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -638,6 +651,7 @@ class SyncManager(private val context: Context) {
                         put("liters", it.liters)
                         put("start_time", it.startTime.toString())
                         put("end_time", it.endTime.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -655,6 +669,7 @@ class SyncManager(private val context: Context) {
                         it.name?.let { name -> put("name", name) }
                         put("start_time", it.startTime.toString())
                         put("end_time", it.endTime.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -664,6 +679,7 @@ class SyncManager(private val context: Context) {
                     healthData.basalMetabolicRate.forEach { add(buildJsonObject {
                         put("watts", it.watts)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -673,6 +689,7 @@ class SyncManager(private val context: Context) {
                     healthData.bodyFat.forEach { add(buildJsonObject {
                         put("percentage", it.percentage)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -682,6 +699,7 @@ class SyncManager(private val context: Context) {
                     healthData.leanBodyMass.forEach { add(buildJsonObject {
                         put("kilograms", it.kilograms)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -691,6 +709,7 @@ class SyncManager(private val context: Context) {
                     healthData.vo2Max.forEach { add(buildJsonObject {
                         put("ml_per_kg_per_min", it.mlPerKgPerMin)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -700,6 +719,7 @@ class SyncManager(private val context: Context) {
                     healthData.boneMass.forEach { add(buildJsonObject {
                         put("kilograms", it.kilograms)
                         put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -8,10 +8,27 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 import java.time.Instant
+
+/** Emit a record's Health Connect provenance as a nested "metadata" object. */
+private fun JsonObjectBuilder.putRecordMetadata(meta: RecordMetadata) {
+    putJsonObject("metadata") {
+        put("data_origin", meta.dataOrigin)
+        put("recording_method", meta.recordingMethod)
+        if (meta.deviceManufacturer != null || meta.deviceModel != null || meta.deviceType != null) {
+            putJsonObject("device") {
+                meta.deviceManufacturer?.let { put("manufacturer", it) }
+                meta.deviceModel?.let { put("model", it) }
+                meta.deviceType?.let { put("type", it) }
+            }
+        }
+    }
+}
 
 class SyncManager(private val context: Context) {
 
@@ -610,6 +627,7 @@ class SyncManager(private val context: Context) {
                         it.strideLengthMeters?.let { strideLengthMeters ->
                             put("stride_length_m", strideLengthMeters)
                         }
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }


### PR DESCRIPTION
Addresses #50 and #42

Adds a `metadata` object to **exercise** records in the webhook payload, exposing the Health Connect provenance that's currently dropped:

```json
"metadata": {
  "data_origin": "com.fitbit.FitbitMobile",
  "recording_method": "automatically_recorded",
  "device": { "manufacturer": "Fitbit", "model": "Sense", "type": 1 }
}
```

### Why
Consumers can't currently attribute or deduplicate records that come from multiple source apps. Concretely (see #50): a treadmill workout arrives twice — once `running_treadmill` from the gym equipment, once an auto-detected `walking` from Fitbit — and without source/recording info there's no reliable way to drop the duplicate. `recording_method` (actively vs automatically recorded), `data_origin`, and `device` each make this resolvable.

### What changed
- `RecordMetadata` + `Metadata.toRecordMetadata()` in `HealthConnectManager.kt` — maps HC `Metadata` (dataOrigin, recordingMethod, device).
- `ExerciseData` gains an optional `metadata` field, populated in `readExerciseData`.
- `JsonObjectBuilder.putRecordMetadata()` helper in `SyncManager.kt`, emitted in the exercise block.

### Scope
Wired into **exercise** as a first step (clearest dedup need), via reusable helpers so the other record types can adopt the same short pattern. Happy to extend to all types in this PR or a follow-up, and to adjust the JSON shape / field names to your preference.

### Testing
`./gradlew :app:compileFossDebugKotlin` builds clean. `recording_method` maps to readable strings; `device` and optional fields are omitted when absent.
