### PR TITLE
fix: retry + throttle Health Connect reads to survive rate limiting

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import androidx.health.connect.client.records.*
 import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.request.AggregateRequest
@@ -797,7 +798,7 @@ class HealthConnectManager(private val context: Context) {
                 metrics = setOf(StepsRecord.COUNT_TOTAL),
                 timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
             )
-            val aggregateResponse = healthConnectClient.aggregate(aggregateRequest)
+            val aggregateResponse = aggregateRL(aggregateRequest)
             val aggregateSteps = aggregateResponse[StepsRecord.COUNT_TOTAL]
 
             val daySteps: Long = if (aggregateSteps != null && aggregateSteps > 0L) {
@@ -1018,7 +1019,7 @@ class HealthConnectManager(private val context: Context) {
                 metrics = setOf(DistanceRecord.DISTANCE_TOTAL),
                 timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
             )
-            val aggregateResponse = healthConnectClient.aggregate(aggregateRequest)
+            val aggregateResponse = aggregateRL(aggregateRequest)
             val aggregateMeters = aggregateResponse[DistanceRecord.DISTANCE_TOTAL]?.inMeters
 
             val dayDistance: Double = if (aggregateMeters != null && aggregateMeters > 0.0) {
@@ -1123,7 +1124,7 @@ class HealthConnectManager(private val context: Context) {
                 metrics = setOf(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL),
                 timeRangeFilter = TimeRangeFilter.between(queryStart, queryEnd)
             )
-            val aggregateResponse = healthConnectClient.aggregate(aggregateRequest)
+            val aggregateResponse = aggregateRL(aggregateRequest)
             val aggregateKcal = aggregateResponse[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inKilocalories
 
             val dayCalories: Double = if (aggregateKcal != null && aggregateKcal > 0.0) {
@@ -1438,7 +1439,7 @@ class HealthConnectManager(private val context: Context) {
             metrics = setOf(StepsRecord.COUNT_TOTAL),
             timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
         )
-        return healthConnectClient.aggregate(request)[StepsRecord.COUNT_TOTAL] ?: 0L
+        return aggregateRL(request)[StepsRecord.COUNT_TOTAL] ?: 0L
     }
 
     private suspend fun aggregateDistanceMeters(startTime: Instant, endTime: Instant): Double {
@@ -1446,7 +1447,7 @@ class HealthConnectManager(private val context: Context) {
             metrics = setOf(DistanceRecord.DISTANCE_TOTAL),
             timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
         )
-        return healthConnectClient.aggregate(request)[DistanceRecord.DISTANCE_TOTAL]?.inMeters ?: 0.0
+        return aggregateRL(request)[DistanceRecord.DISTANCE_TOTAL]?.inMeters ?: 0.0
     }
 
     private suspend fun aggregateActiveCalories(startTime: Instant, endTime: Instant): Double {
@@ -1454,7 +1455,7 @@ class HealthConnectManager(private val context: Context) {
             metrics = setOf(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL),
             timeRangeFilter = TimeRangeFilter.between(startTime, endTime),
         )
-        return healthConnectClient.aggregate(request)[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]
+        return aggregateRL(request)[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]
             ?.inKilocalories ?: 0.0
     }
 
@@ -1469,7 +1470,7 @@ class HealthConnectManager(private val context: Context) {
                 metrics = setOf(StepsCadenceRecord.RATE_AVG, StepsCadenceRecord.RATE_MAX),
                 timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
             )
-            val response = healthConnectClient.aggregate(request)
+            val response = aggregateRL(request)
             StepsCadenceMetrics(
                 avg = response[StepsCadenceRecord.RATE_AVG]?.takeIf { it > 0.0 },
                 max = response[StepsCadenceRecord.RATE_MAX]?.takeIf { it > 0.0 }
@@ -1720,7 +1721,12 @@ class HealthConnectManager(private val context: Context) {
     private suspend fun <T : Record> readAllRecords(request: ReadRecordsRequest<T>): List<T> {
         val all = mutableListOf<T>()
         var token: String? = null
+        var firstPage = true
         do {
+            // Gentle inter-page throttle so a multi-page read (e.g. heart rate over a
+            // long window) doesn't trip Health Connect's burst quota in the first place.
+            if (!firstPage) delay(120)
+            firstPage = false
             val current = if (token == null) request else ReadRecordsRequest(
                 recordType = request.recordType,
                 timeRangeFilter = request.timeRangeFilter,
@@ -1729,12 +1735,40 @@ class HealthConnectManager(private val context: Context) {
                 pageSize = request.pageSize,
                 pageToken = token,
             )
-            val page = healthConnectClient.readRecords(current)
+            val page = withHealthConnectRetry { healthConnectClient.readRecords(current) }
             all.addAll(page.records)
             token = page.pageToken
         } while (token != null)
         return all
     }
+
+    /**
+     * Retries a Health Connect call when the platform throws its rate-limit /
+     * quota-exceeded error, backing off exponentially (1s, 2s, 4s, 8s). Any other
+     * error propagates immediately. This mitigates the periodic (burst) quota; the
+     * separate daily quota still needs real time to replenish, so after the last
+     * attempt the original exception is rethrown for the UI to surface.
+     */
+    private suspend fun <T> withHealthConnectRetry(maxAttempts: Int = 4, block: suspend () -> T): T {
+        var attempt = 0
+        var delayMs = 1_000L
+        while (true) {
+            try {
+                return block()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                val msg = e.message?.lowercase().orEmpty()
+                val isRateLimit = msg.contains("rate limit") || msg.contains("quota")
+                attempt++
+                if (!isRateLimit || attempt >= maxAttempts) throw e
+                delay(delayMs)
+                delayMs = (delayMs * 2).coerceAtMost(8_000L)
+            }
+        }
+    }
+
+    private suspend fun aggregateRL(request: AggregateRequest) =
+        withHealthConnectRetry { healthConnectClient.aggregate(request) }
 
     fun isHealthConnectAvailable(): Boolean {
         return try {


### PR DESCRIPTION
## Summary

Re-lands #46 onto current `main` after the history rewrite closed that PR.

- Wrap `readRecords` and `aggregate` calls in `withHealthConnectRetry()` — exponential backoff (1s → 2s → 4s → 8s, 4 attempts) on rate-limit / quota errors
- Add 120 ms inter-page delay in `readAllRecords` to reduce burst quota hits
- Preserves the newer aggregate + raw-record fallback logic from #48

Fixes #45. Supersedes #46.

Credit: @w3rc — original implementation and on-device verification.

## Test plan

- [x] `./gradlew :app:assembleFossDebug` → BUILD SUCCESSFUL
- [ ] Manual sync with multiple data types over a longer range (previously rate-limited) completes successfully