### PR TITLE
feat: add metadata to steps, distance, and active_calories records

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -180,7 +180,8 @@ fun Metadata.toRecordMetadata(): RecordMetadata = RecordMetadata(
 data class StepsData(
     val count: Long,
     val startTime: Instant,
-    val endTime: Instant
+    val endTime: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class SleepData(
@@ -216,13 +217,15 @@ data class HeartRateVariabilityData(
 data class DistanceData(
     val meters: Double,
     val startTime: Instant,
-    val endTime: Instant
+    val endTime: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class ActiveCaloriesData(
     val calories: Double,
     val startTime: Instant,
-    val endTime: Instant
+    val endTime: Instant,
+    val metadata: RecordMetadata? = null
 )
 
 data class TotalCaloriesData(
@@ -879,7 +882,7 @@ class HealthConnectManager(private val context: Context) {
         return readAllRecords(request)
             .filter { lastSync == null || it.endTime >= lastSync }
             .filter { it.count > 0 }
-            .map { StepsData(count = it.count, startTime = it.startTime, endTime = it.endTime) }
+            .map { StepsData(count = it.count, startTime = it.startTime, endTime = it.endTime, metadata = it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBucketedStepsData(
@@ -1110,7 +1113,7 @@ class HealthConnectManager(private val context: Context) {
         return readAllRecords(request)
             .filter { lastSync == null || it.endTime >= lastSync }
             .filter { it.distance.inMeters > 0.0 }
-            .map { DistanceData(it.distance.inMeters, it.startTime, it.endTime) }
+            .map { DistanceData(it.distance.inMeters, it.startTime, it.endTime, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBucketedDistanceData(
@@ -1217,7 +1220,7 @@ class HealthConnectManager(private val context: Context) {
         return readAllRecords(request)
             .filter { lastSync == null || it.endTime >= lastSync }
             .filter { it.energy.inKilocalories > 0.0 }
-            .map { ActiveCaloriesData(it.energy.inKilocalories, it.startTime, it.endTime) }
+            .map { ActiveCaloriesData(it.energy.inKilocalories, it.startTime, it.endTime, it.metadata.toRecordMetadata()) }
     }
 
     private suspend fun readBucketedActiveCaloriesData(

--- a/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
+++ b/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
@@ -3,6 +3,7 @@ package com.hcwebhook.app
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -33,6 +34,10 @@ object MockPayloadBuilder {
                         put("count", 8432L)
                         put("start_time", yesterday.toString())
                         put("end_time", t(10, 30).toString())
+                        putJsonObject("metadata") {
+                            put("data_origin", "com.google.android.apps.fitness")
+                            put("recording_method", "automatically_recorded")
+                        }
                     })
                 }
             }
@@ -80,6 +85,10 @@ object MockPayloadBuilder {
                         put("meters", 5420.0)
                         put("start_time", t(8, 0).toString())
                         put("end_time", t(9, 0).toString())
+                        putJsonObject("metadata") {
+                            put("data_origin", "com.google.android.apps.fitness")
+                            put("recording_method", "automatically_recorded")
+                        }
                     })
                 }
             }
@@ -89,6 +98,10 @@ object MockPayloadBuilder {
                         put("calories", 312.0)
                         put("start_time", t(8, 0).toString())
                         put("end_time", t(9, 0).toString())
+                        putJsonObject("metadata") {
+                            put("data_origin", "com.google.android.apps.fitness")
+                            put("recording_method", "automatically_recorded")
+                        }
                     })
                 }
             }

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -491,6 +491,7 @@ class SyncManager(private val context: Context) {
                             put("count", step.count)
                             put("start_time", step.startTime.toString())
                             put("end_time", step.endTime.toString())
+                            step.metadata?.let { meta -> putRecordMetadata(meta) }
                         })
                     }
                 }
@@ -558,6 +559,7 @@ class SyncManager(private val context: Context) {
                         put("meters", it.meters)
                         put("start_time", it.startTime.toString())
                         put("end_time", it.endTime.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }
@@ -568,6 +570,7 @@ class SyncManager(private val context: Context) {
                         put("calories", it.calories)
                         put("start_time", it.startTime.toString())
                         put("end_time", it.endTime.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
                     }) }
                 }
             }


### PR DESCRIPTION
## Summary
StepsData, DistanceData, and ActiveCaloriesData were the only interval types missing the metadata field. Raw-mode reads now include data_origin and recording_method so consumers can identify the source app/device and deduplicate records from multiple sources (e.g. Garmin + a second band). Bucketed and daily aggregations keep metadata null since they merge across records. Mock payload updated to reflect the new field.

## Related
- Closes #57 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Build/CI change

## Checklist
- [x] I tested this change locally
- [ ] I updated documentation (if needed)
- [ ] I added/updated tests (if needed)
- [ ] I verified there are no breaking changes
- [ ] I checked for sensitive data/secrets

## Screenshots / Recordings (if UI changes)
- N/A

## Additional notes
- N/A
