### PR TITLE
✨ feat(exercise): include session title in webhook payload

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -300,6 +300,7 @@ data class RestingHeartRateData(
 
 data class ExerciseData(
     val type: String,
+    val title: String? = null,
     val startTime: Instant,
     val endTime: Instant,
     val duration: Duration,
@@ -1560,6 +1561,7 @@ class HealthConnectManager(private val context: Context) {
                 val cadenceMetrics = if (includeSteps) readStepsCadenceMetrics(it.startTime, it.endTime) else StepsCadenceMetrics()
                 ExerciseData(
                     type = it.exerciseType.toString(),
+                    title = it.title?.takeIf { title -> title.isNotBlank() },
                     startTime = it.startTime,
                     endTime = it.endTime,
                     duration = duration,

--- a/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
+++ b/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
@@ -172,6 +172,7 @@ object MockPayloadBuilder {
                 putJsonArray("exercise") {
                     add(buildJsonObject {
                         put("type", "running")
+                        put("title", "Morning Run")
                         put("start_time", t(8, 0).toString())
                         put("end_time", t(9, 0).toString())
                         put("duration_seconds", 3600L)

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -703,6 +703,7 @@ class SyncManager(private val context: Context) {
                 putJsonArray("exercise") {
                     healthData.exercise.forEach { add(buildJsonObject {
                         put("type", it.type)
+                        it.title?.let { title -> put("title", title) }
                         put("start_time", it.startTime.toString())
                         put("end_time", it.endTime.toString())
                         put("duration_seconds", it.duration.seconds)


### PR DESCRIPTION
## Summary
- Include Health Connect `ExerciseSessionRecord.title` in exercise webhook records as `title`
- Update mock payload to match
- Addresses [FeedbackJar: Include exercise names in webhook data](https://feedback.hcwebhook.com/posts/include-exercise-names-in-webhook-data/cmshi1n2i0005cw3r6tbwgrms)
