### PR TITLE
🐛 fix(sync): prevent duplicate scheduled sync alarms

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/PreferencesManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/PreferencesManager.kt
@@ -242,8 +242,10 @@ class PreferencesManager(context: Context) {
             return try {
                 Json.decodeFromString<List<ScheduledSync>>(syncsJson)
             } catch (e: Exception) {
-                // If JSON parsing fails, return default schedules
-                getDefaultScheduledSyncs()
+                // If JSON parsing fails, persist defaults so schedule IDs stay stable
+                val defaults = getDefaultScheduledSyncs()
+                setScheduledSyncs(defaults)
+                defaults
             }
         }
         
@@ -256,7 +258,7 @@ class PreferencesManager(context: Context) {
         // Check if these are default values (8:00 and 21:00)
         val isDefaultValues = morningHour == 8 && morningMinute == 0 && eveningHour == 21 && eveningMinute == 0
         
-        return if (isDefaultValues) {
+        val syncs = if (isDefaultValues) {
             getDefaultScheduledSyncs()
         } else {
             // Migrate user's custom times
@@ -265,6 +267,9 @@ class PreferencesManager(context: Context) {
                 ScheduledSync.create(eveningHour, eveningMinute, "Evening")
             )
         }
+        // Persist so AlarmManager PendingIntent request codes stay stable across restarts
+        setScheduledSyncs(syncs)
+        return syncs
     }
 
     fun setScheduledSyncs(syncs: List<ScheduledSync>) {

--- a/app/src/main/java/com/hcwebhook/app/ScheduledSyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/ScheduledSyncManager.kt
@@ -35,6 +35,9 @@ class ScheduledSyncManager(private val context: Context) {
             return
         }
         
+        // Cancel known alarms first so repeated scheduleAllAlarms() cannot stack duplicates
+        cancelAllAlarms()
+
         val schedules = preferencesManager.getScheduledSyncs()
         // Only schedule enabled schedules
         schedules.filter { it.enabled }.forEach { schedule ->

--- a/app/src/main/java/com/hcwebhook/app/SyncForegroundService.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncForegroundService.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A short-lived foreground service that performs a single background sync.
@@ -57,30 +58,42 @@ class SyncForegroundService : Service() {
         val scheduleId = intent?.getStringExtra(EXTRA_SCHEDULE_ID)
         Log.d(TAG, "Starting foreground sync (scheduleId=$scheduleId)")
 
+        if (!isSyncRunning.compareAndSet(false, true)) {
+            Log.d(TAG, "Sync already in progress, skipping duplicate start (scheduleId=$scheduleId)")
+            // Still reschedule the incoming alarm so it is not lost while a sync runs
+            rescheduleAlarmIfNeeded(scheduleId)
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+
         scope.launch {
             try {
                 val syncManager = SyncManager(this@SyncForegroundService)
                 syncManager.performSync(syncType = "auto")
 
                 // Reschedule the daily alarm for the next occurrence
-                if (scheduleId != null) {
-                    val prefsManager = PreferencesManager(this@SyncForegroundService)
-                    val schedule = prefsManager.getScheduledSyncs().find { it.id == scheduleId }
-                    if (schedule != null && schedule.enabled) {
-                        ScheduledSyncManager(this@SyncForegroundService).scheduleAlarm(schedule)
-                        Log.d(TAG, "Rescheduled alarm for next day: $scheduleId")
-                    }
-                }
+                rescheduleAlarmIfNeeded(scheduleId)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Sync failed in foreground service: ${e.message}", e)
             } finally {
+                isSyncRunning.set(false)
                 stopSelf(startId)
             }
         }
 
         return START_NOT_STICKY
+    }
+
+    private fun rescheduleAlarmIfNeeded(scheduleId: String?) {
+        if (scheduleId == null) return
+        val prefsManager = PreferencesManager(this)
+        val schedule = prefsManager.getScheduledSyncs().find { it.id == scheduleId }
+        if (schedule != null && schedule.enabled) {
+            ScheduledSyncManager(this).scheduleAlarm(schedule)
+            Log.d(TAG, "Rescheduled alarm for next day: $scheduleId")
+        }
     }
 
     override fun onDestroy() {
@@ -93,6 +106,7 @@ class SyncForegroundService : Service() {
         private const val NOTIFICATION_ID = 2001
         const val CHANNEL_ID = "hc_sync_service"
         const val EXTRA_SCHEDULE_ID = "schedule_id"
+        private val isSyncRunning = AtomicBoolean(false)
 
         fun start(context: Context, scheduleId: String? = null) {
             val intent = Intent(context, SyncForegroundService::class.java).apply {

--- a/app/src/main/java/com/hcwebhook/app/screens/ConfigurationScreen.kt
+++ b/app/src/main/java/com/hcwebhook/app/screens/ConfigurationScreen.kt
@@ -568,7 +568,7 @@ fun ConfigurationScreen(
                             ) { Text(stringResource(R.string.config_sync_mode_interval)) }
                             SegmentedButton(
                                 selected = syncMode == SyncMode.SCHEDULED,
-                                onClick = { syncMode = SyncMode.SCHEDULED; preferencesManager.setSyncMode(SyncMode.SCHEDULED); (activity.application as? HCWebhookApplication)?.cancelSyncWork(); ScheduledSyncManager(context).scheduleAllAlarms() },
+                                onClick = { syncMode = SyncMode.SCHEDULED; preferencesManager.setSyncMode(SyncMode.SCHEDULED); preferencesManager.setScheduledSyncs(scheduledSyncs); (activity.application as? HCWebhookApplication)?.cancelSyncWork(); ScheduledSyncManager(context).scheduleAllAlarms() },
                                 shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
                             ) { Text(stringResource(R.string.config_sync_mode_scheduled)) }
                         }


### PR DESCRIPTION
## Summary
- Persist scheduled sync IDs on first read so AlarmManager request codes stay stable
- Cancel existing alarms before rescheduling
- Persist schedules when switching to SCHEDULED mode
- Guard `SyncForegroundService` against parallel `performSync` runs
- Addresses [FeedbackJar: Fix scheduled sync duplication](https://feedback.hcwebhook.com/posts/fix-scheduled-sync-duplication/cms9u1ofc0001cw3r7o7gykfp)

## Test plan
- [ ] Fresh install / clear app data, enable SCHEDULED mode with defaults
- [ ] Force-stop and reopen the app several times; confirm only one alarm per schedule
- [ ] Wait for a scheduled sync (or advance device time) and confirm a single webhook delivery
- [ ] Note: orphan alarms from pre-fix unstable IDs may fire once after upgrade