### PR TITLE
✨ feat(health): add body water mass and computed BMI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <uses-permission android:name="android.permission.health.READ_BASAL_METABOLIC_RATE" />
     <uses-permission android:name="android.permission.health.READ_BODY_FAT" />
     <uses-permission android:name="android.permission.health.READ_LEAN_BODY_MASS" />
+    <uses-permission android:name="android.permission.health.READ_BODY_WATER_MASS" />
     <uses-permission android:name="android.permission.health.READ_VO2_MAX" />
     <uses-permission android:name="android.permission.health.READ_BONE_MASS" />
     <uses-permission android:name="android.permission.health.READ_MENSTRUATION" />

--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -88,6 +88,9 @@ enum class HealthDataType(val nameResId: Int, val recordClass: KClass<out Record
     LEAN_BODY_MASS(
         R.string.dt_lbm_name, LeanBodyMassRecord::class, R.string.dt_lbm_rationale
     ),
+    BODY_WATER_MASS(
+        R.string.dt_bwm_name, BodyWaterMassRecord::class, R.string.dt_bwm_rationale
+    ),
     VO2_MAX(
         R.string.dt_vo2_name, Vo2MaxRecord::class, R.string.dt_vo2_rationale
     ),
@@ -140,6 +143,7 @@ data class HealthData(
     val basalMetabolicRate: List<BasalMetabolicRateData>,
     val bodyFat: List<BodyFatData>,
     val leanBodyMass: List<LeanBodyMassData>,
+    val bodyWaterMass: List<BodyWaterMassData>,
     val vo2Max: List<Vo2MaxData>,
     val boneMass: List<BoneMassData>,
     val menstruationFlow: List<MenstruationFlowData>,
@@ -350,6 +354,12 @@ data class LeanBodyMassData(
     val metadata: RecordMetadata? = null
 )
 
+data class BodyWaterMassData(
+    val kilograms: Double,
+    val time: Instant,
+    val metadata: RecordMetadata? = null
+)
+
 data class Vo2MaxData(
     val mlPerKgPerMin: Double,
     val time: Instant,
@@ -487,6 +497,8 @@ class HealthConnectManager(private val context: Context) {
                 readBodyFatData(startTime, endTime, lastSyncTimestamps[HealthDataType.BODY_FAT]) else emptyList()
             val leanBodyMassData = if (HealthDataType.LEAN_BODY_MASS in enabledTypes)
                 readLeanBodyMassData(startTime, endTime, lastSyncTimestamps[HealthDataType.LEAN_BODY_MASS]) else emptyList()
+            val bodyWaterMassData = if (HealthDataType.BODY_WATER_MASS in enabledTypes)
+                readBodyWaterMassData(startTime, endTime, lastSyncTimestamps[HealthDataType.BODY_WATER_MASS]) else emptyList()
             val vo2MaxData = if (HealthDataType.VO2_MAX in enabledTypes)
                 readVo2MaxData(startTime, endTime, lastSyncTimestamps[HealthDataType.VO2_MAX]) else emptyList()
             val boneMassData = if (HealthDataType.BONE_MASS in enabledTypes)
@@ -529,6 +541,7 @@ class HealthConnectManager(private val context: Context) {
                 basalMetabolicRate = basalMetabolicRateData,
                 bodyFat = bodyFatData,
                 leanBodyMass = leanBodyMassData,
+                bodyWaterMass = bodyWaterMassData,
                 vo2Max = vo2MaxData,
                 boneMass = boneMassData,
                 menstruationFlow = menstruationFlowData,
@@ -732,6 +745,12 @@ class HealthConnectManager(private val context: Context) {
         HealthDataType.LEAN_BODY_MASS -> latestMetric(
             type,
             readLeanBodyMassData(dayStart, dayEnd, null).maxByOrNull { it.time }?.kilograms,
+            DashboardFormatter::formatWeightKg,
+            R.string.dashboard_sub_kg_latest,
+        )
+        HealthDataType.BODY_WATER_MASS -> latestMetric(
+            type,
+            readBodyWaterMassData(dayStart, dayEnd, null).maxByOrNull { it.time }?.kilograms,
             DashboardFormatter::formatWeightKg,
             R.string.dashboard_sub_kg_latest,
         )
@@ -1836,6 +1855,13 @@ class HealthConnectManager(private val context: Context) {
             .map { LeanBodyMassData(it.mass.inKilograms, it.time, it.metadata.toRecordMetadata()) }
     }
 
+    private suspend fun readBodyWaterMassData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<BodyWaterMassData> {
+        val request = ReadRecordsRequest(recordType = BodyWaterMassRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
+        val response = readAllRecords(request)
+        return response.filter { lastSync == null || it.time >= lastSync }
+            .map { BodyWaterMassData(it.mass.inKilograms, it.time, it.metadata.toRecordMetadata()) }
+    }
+
     private suspend fun readVo2MaxData(startTime: Instant, endTime: Instant, lastSync: Instant?): List<Vo2MaxData> {
         val request = ReadRecordsRequest(recordType = Vo2MaxRecord::class, timeRangeFilter = TimeRangeFilter.between(startTime, endTime))
         val response = readAllRecords(request)
@@ -2053,6 +2079,7 @@ class HealthConnectManager(private val context: Context) {
             HealthPermission.getReadPermission(BasalMetabolicRateRecord::class),
             HealthPermission.getReadPermission(BodyFatRecord::class),
             HealthPermission.getReadPermission(LeanBodyMassRecord::class),
+            HealthPermission.getReadPermission(BodyWaterMassRecord::class),
             HealthPermission.getReadPermission(Vo2MaxRecord::class),
             HealthPermission.getReadPermission(BoneMassRecord::class),
             HealthPermission.getReadPermission(MenstruationFlowRecord::class),

--- a/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
+++ b/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
@@ -223,6 +223,22 @@ object MockPayloadBuilder {
                     add(buildJsonObject { put("kilograms", 61.5); put("time", t(7, 30).toString()) })
                 }
             }
+            if (include(HealthDataType.BODY_WATER_MASS.name)) {
+                putJsonArray("body_water_mass") {
+                    add(buildJsonObject { put("kilograms", 42.0); put("time", t(7, 30).toString()) })
+                }
+            }
+            if (include(HealthDataType.WEIGHT.name) && include(HealthDataType.HEIGHT.name)) {
+                // BMI = 75.5 / (1.78²) ≈ 23.83; mirrors SyncManager compute path
+                putJsonArray("bmi") {
+                    add(buildJsonObject {
+                        put("value", 75.5 / (1.78 * 1.78))
+                        put("time", t(7, 30).toString())
+                        put("weight_kg", 75.5)
+                        put("height_meters", 1.78)
+                    })
+                }
+            }
             if (include(HealthDataType.VO2_MAX.name)) {
                 putJsonArray("vo2_max") {
                     add(buildJsonObject { put("ml_per_kg_per_min", 48.0); put("time", t(9, 0).toString()) })

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -250,6 +250,7 @@ class SyncManager(private val context: Context) {
             basalMetabolicRate = if ("BASAL_METABOLIC_RATE" in allowed) data.basalMetabolicRate else emptyList(),
             bodyFat = if ("BODY_FAT" in allowed) data.bodyFat else emptyList(),
             leanBodyMass = if ("LEAN_BODY_MASS" in allowed) data.leanBodyMass else emptyList(),
+            bodyWaterMass = if ("BODY_WATER_MASS" in allowed) data.bodyWaterMass else emptyList(),
             vo2Max = if ("VO2_MAX" in allowed) data.vo2Max else emptyList(),
             boneMass = if ("BONE_MASS" in allowed) data.boneMass else emptyList(),
             menstruationFlow = if ("MENSTRUATION_FLOW" in allowed) data.menstruationFlow else emptyList(),
@@ -270,7 +271,7 @@ class SyncManager(private val context: Context) {
                 data.bodyTemperature.size + data.skinTemperature.size + data.respiratoryRate.size +
                 data.restingHeartRate.size + data.exercise.size + data.hydration.size +
                 data.nutrition.size + data.basalMetabolicRate.size + data.bodyFat.size +
-                data.leanBodyMass.size + data.vo2Max.size + data.boneMass.size +
+                data.leanBodyMass.size + data.bodyWaterMass.size + data.vo2Max.size + data.boneMass.size +
                 data.menstruationFlow.size + data.menstruationPeriod.size +
                 data.intermenstrualBleeding.size + data.ovulationTest.size +
                 data.cervicalMucus.size + data.sexualActivity.size + data.basalBodyTemperature.size
@@ -286,6 +287,7 @@ class SyncManager(private val context: Context) {
                 data.respiratoryRate.isEmpty() && data.restingHeartRate.isEmpty() && data.exercise.isEmpty() &&
                 data.hydration.isEmpty() && data.nutrition.isEmpty() &&
                 data.basalMetabolicRate.isEmpty() && data.bodyFat.isEmpty() && data.leanBodyMass.isEmpty() &&
+                data.bodyWaterMass.isEmpty() &&
                 data.vo2Max.isEmpty() && data.boneMass.isEmpty() &&
                 data.menstruationFlow.isEmpty() && data.menstruationPeriod.isEmpty() &&
                 data.intermenstrualBleeding.isEmpty() && data.ovulationTest.isEmpty() &&
@@ -405,6 +407,10 @@ class SyncManager(private val context: Context) {
         if (data.leanBodyMass.isNotEmpty()) {
             preferencesManager.setLastSyncTimestamp(HealthDataType.LEAN_BODY_MASS, data.leanBodyMass.maxOf { it.time }.toEpochMilli())
             syncCounts[HealthDataType.LEAN_BODY_MASS] = data.leanBodyMass.size
+        }
+        if (data.bodyWaterMass.isNotEmpty()) {
+            preferencesManager.setLastSyncTimestamp(HealthDataType.BODY_WATER_MASS, data.bodyWaterMass.maxOf { it.time }.toEpochMilli())
+            syncCounts[HealthDataType.BODY_WATER_MASS] = data.bodyWaterMass.size
         }
         if (data.vo2Max.isNotEmpty()) {
             preferencesManager.setLastSyncTimestamp(HealthDataType.VO2_MAX, data.vo2Max.maxOf { it.time }.toEpochMilli())
@@ -785,6 +791,32 @@ class SyncManager(private val context: Context) {
                 }
             }
 
+            if (healthData.bodyWaterMass.isNotEmpty()) {
+                putJsonArray("body_water_mass") {
+                    healthData.bodyWaterMass.forEach { add(buildJsonObject {
+                        put("kilograms", it.kilograms)
+                        put("time", it.time.toString())
+                        it.metadata?.let { meta -> putRecordMetadata(meta) }
+                    }) }
+                }
+            }
+
+            // Health Connect has no BMI record type. Compute BMI = kg / m² when both
+            // weight and height lists are present (enabled + non-empty after filter).
+            // Pair each weight with the height closest in time.
+            if (healthData.weight.isNotEmpty() && healthData.height.isNotEmpty()) {
+                putJsonArray("bmi") {
+                    computeBmiEntries(healthData.weight, healthData.height).forEach { entry ->
+                        add(buildJsonObject {
+                            put("value", entry.value)
+                            put("time", entry.time.toString())
+                            put("weight_kg", entry.weightKg)
+                            put("height_meters", entry.heightMeters)
+                        })
+                    }
+                }
+            }
+
             if (healthData.vo2Max.isNotEmpty()) {
                 putJsonArray("vo2_max") {
                     healthData.vo2Max.forEach { add(buildJsonObject {
@@ -877,6 +909,34 @@ class SyncManager(private val context: Context) {
         } // End of buildJsonObject block
 
         return json.toString()
+    }
+
+    private data class BmiEntry(
+        val value: Double,
+        val time: Instant,
+        val weightKg: Double,
+        val heightMeters: Double
+    )
+
+    /** BMI = kg / m². Pair each weight with the height record closest in time. */
+    private fun computeBmiEntries(
+        weights: List<WeightData>,
+        heights: List<HeightData>
+    ): List<BmiEntry> {
+        if (weights.isEmpty() || heights.isEmpty()) return emptyList()
+        return weights.mapNotNull { weight ->
+            val height = heights.minByOrNull { h ->
+                kotlin.math.abs(h.time.toEpochMilli() - weight.time.toEpochMilli())
+            } ?: return@mapNotNull null
+            if (height.meters <= 0.0) return@mapNotNull null
+            val bmi = weight.kilograms / (height.meters * height.meters)
+            BmiEntry(
+                value = bmi,
+                time = weight.time,
+                weightKg = weight.kilograms,
+                heightMeters = height.meters
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/hcwebhook/app/dashboard/DashboardMetricPresentation.kt
+++ b/app/src/main/java/com/hcwebhook/app/dashboard/DashboardMetricPresentation.kt
@@ -49,6 +49,7 @@ object DashboardMetricPresentation {
         HealthDataType.TOTAL_CALORIES -> style(Icons.Filled.LocalFireDepartment, IconBackgroundRed, IconTintRed)
         HealthDataType.WEIGHT,
         HealthDataType.LEAN_BODY_MASS,
+        HealthDataType.BODY_WATER_MASS,
         HealthDataType.BONE_MASS -> style(Icons.Filled.Scale, IconBackgroundBlue, IconTintBlue)
         HealthDataType.HEIGHT -> style(Icons.Filled.Speed, IconBackgroundGreen, IconTintGreen)
         HealthDataType.BLOOD_PRESSURE -> style(Icons.Filled.MonitorHeart, IconBackgroundRed, IconTintRed)

--- a/app/src/main/java/com/hcwebhook/app/screens/OnboardingScreen.kt
+++ b/app/src/main/java/com/hcwebhook/app/screens/OnboardingScreen.kt
@@ -289,6 +289,7 @@ private fun DataTypesPage() {
                 HealthDataType.HEIGHT,
                 HealthDataType.BODY_FAT,
                 HealthDataType.LEAN_BODY_MASS,
+                HealthDataType.BODY_WATER_MASS,
                 HealthDataType.BONE_MASS,
                 HealthDataType.BASAL_METABOLIC_RATE,
                 HealthDataType.VO2_MAX
@@ -510,6 +511,7 @@ fun iconForDataType(type: HealthDataType): ImageVector = when (type) {
     HealthDataType.HEIGHT              -> Icons.Filled.Height
     HealthDataType.BODY_FAT            -> Icons.Filled.MonitorWeight
     HealthDataType.LEAN_BODY_MASS      -> Icons.Filled.FitnessCenter
+    HealthDataType.BODY_WATER_MASS     -> Icons.Filled.WaterDrop
     HealthDataType.BONE_MASS           -> Icons.Filled.Accessibility
     HealthDataType.BASAL_METABOLIC_RATE -> Icons.Filled.LocalFireDepartment
     HealthDataType.VO2_MAX             -> Icons.Filled.Speed

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">Leiten Sie prozentuale Körperfettmesswerte weiter, um Verlaufe der Körperbestandteile auf Dauer abzulesen.</string>
     <string name="dt_lbm_name">Mageres Körpergewicht</string>
     <string name="dt_lbm_rationale">Senden Sie Masse an den Webhook für Muskelzu- oder abnahme und zur Unterstützung des Wachstumsmanagements.</string>
+    <string name="dt_bwm_name">Körperwassermasse</string>
+    <string name="dt_bwm_rationale">Leiten Sie Körperwassermasse-Messwerte an Ihren Webhook weiter, um Hydration und Körperzusammensetzung von Smart-Waagen zu verfolgen.</string>
     <string name="dt_vo2_name">VO₂ Max</string>
     <string name="dt_vo2_rationale">Tragen Sie VO₂ max-Daten zu Ihrem Webhook weiter zur Überwachung Ihrer eigenen körperlichen Ausdauer und Verbesserungen.</string>
     <string name="dt_bone_name">Knochenmasse</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">Muestra las tendencias generales basándose en tu propia perspectiva física enviada directamente para fines útiles o proyecciones comparativas.</string>
     <string name="dt_lbm_name">Masa corporal magra</string>
     <string name="dt_lbm_rationale">Determine cuál es su porcentaje real exento de su volumen muscular usando directamente un registro contable y directo en tu Webhook.</string>
+    <string name="dt_bwm_name">Masa de agua corporal</string>
+    <string name="dt_bwm_rationale">Envía mediciones de masa de agua corporal a tu webhook para seguir la hidratación y la composición corporal de básculas inteligentes.</string>
     <string name="dt_vo2_name">VO₂ Máx</string>
     <string name="dt_vo2_rationale">Monitoreo en torno a tu aguante cardiorrespiratorio a partir de las cantidades ingresadas durante la ejercitación y puestas en tu base.</string>
     <string name="dt_bone_name">Masa ósea</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">Transmettez vos relevés sur le pourcentage de masse grasse pour surveiller les évolutions de composition physique et corpulence.</string>
     <string name="dt_lbm_name">Masse corporelle maigre</string>
     <string name="dt_lbm_rationale">Envoyez la teneur en masse maigre à votre webhook afin de surveiller la prise et la perte musculaires.</string>
+    <string name="dt_bwm_name">Masse d\'eau corporelle</string>
+    <string name="dt_bwm_rationale">Transmettez les mesures de masse d\'eau corporelle à votre webhook pour suivre l\'hydratation et la composition corporelle.</string>
     <string name="dt_vo2_name">VO₂ Max</string>
     <string name="dt_vo2_rationale">Transmetsez les données de VO₂ max à votre webhook pour suivre l\’endurance et surveiller les progrès et améliorations de condition.</string>
     <string name="dt_bone_name">Masse osseuse</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">Trasmetti ai Webhook i valori delle analisi che consentiranno di confrontare periodi dei vostri risultati in salute.</string>
     <string name="dt_lbm_name">Massa magra</string>
     <string name="dt_lbm_rationale">Trasmetti misure sulla muscolosità nei resoconti forniti tramite il personale Webhook inviato come report.</string>
+    <string name="dt_bwm_name">Massa d\'acqua corporea</string>
+    <string name="dt_bwm_rationale">Invia le misure di massa d\'acqua corporea al webhook per monitorare idratazione e composizione corporea dalle bilance smart.</string>
     <string name="dt_vo2_name">VO₂ Max</string>
     <string name="dt_vo2_rationale">Misura di tolleranza di sopportazione sportiva valutando massimi che passiamo sul tuo riferimento del Webhook.</string>
     <string name="dt_bone_name">Massa ossea</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">体脂肪率の計測をWebhookに送信し、体組成の変化と個人のフィットネス進捗を長期間監視します。</string>
     <string name="dt_lbm_name">除脂肪体重</string>
     <string name="dt_lbm_rationale">筋肉の増減など体組成の再構成の過程を確認するために除脂肪体重データをWebhook経由で自動取得させます。</string>
+    <string name="dt_bwm_name">体水分量</string>
+    <string name="dt_bwm_rationale">スマート体重計の体水分量をWebhookに送信し、水分状態と体組成を追跡します。</string>
     <string name="dt_vo2_name">VO₂ Max</string>
     <string name="dt_vo2_rationale">最大酸素摂取量(VO₂ Max)の読み取りデータを送信して、有酸素運動能力の改善点や持久力の効果を測定します。</string>
     <string name="dt_bone_name">骨量</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">신체 구성을 측정 관리하고 운동 진행에 맞춘 장기 목표를 확인하는 체지방률 통계를 직접 전송할 수 있습니다.</string>
     <string name="dt_lbm_name">제지방 체중</string>
     <string name="dt_lbm_rationale">제지방량 데이터를 통해 장기적인 사용자의 신체 개조 과정에서 생기게되는 근육량 등의 추적 프로세스를 가동합니다.</string>
+    <string name="dt_bwm_name">체수분량</string>
+    <string name="dt_bwm_rationale">스마트 체중계의 체수분량 측정을 웹훅으로 보내 수분 상태와 체성분을 추적합니다.</string>
     <string name="dt_vo2_name">최대 산소 섭취량</string>
     <string name="dt_vo2_rationale">VO₂ max 값을 Webhook으로 보내 지구력 평가나 각 회차별 개선되는 심박 및 운동능력을 분석하고 수치를 체크합니다.</string>
     <string name="dt_bone_name">골량</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">Registra e direciona volumes nos rastreios no corpo enviando dados ao webhook nas finalizações desportivas contábeis.</string>
     <string name="dt_lbm_name">Massa Corporal Magra</string>
     <string name="dt_lbm_rationale">Massa enxuta encaminhada a base contábil para recompor teu painéis enviando via webhook no progresso e acompanhamento estrito teu corpo.</string>
+    <string name="dt_bwm_name">Massa de água corporal</string>
+    <string name="dt_bwm_rationale">Envie medições de massa de água corporal ao webhook para acompanhar hidratação e composição corporal de balanças inteligentes.</string>
     <string name="dt_vo2_name">VO₂ Máx</string>
     <string name="dt_vo2_rationale">Sinalize seus limites respiratórios na rotina gerada enviando sua taxa de força cardiorrespiratória ao painel com seu webhook acompanhando sua base.</string>
     <string name="dt_bone_name">Massa Óssea</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">உடல் கொழுப்பு சதவிகித அளவீடுகளை அனுப்பி உடல் அமைப்பில் உள்ள மாற்றங்கள் மற்றும் உடற்பயிற்சியின் வளர்ச்சியைக் கண்காணிக்கச் செய்கிறது.</string>
     <string name="dt_lbm_name">தசை நிறை</string>
     <string name="dt_lbm_rationale">உடல் தசை நிறையின் அளவீட்டினை Webhook-க்கு வழங்கி, தசை வளர்ச்சி மற்றும் இழப்புகளைத் தொடர்ந்து கண்காணிக்க அனுமதிக்கிறது.</string>
+    <string name="dt_bwm_name">உடல் நீர் நிறை</string>
+    <string name="dt_bwm_rationale">ஸ்மார்ட் எடை அளவீடுகளிலிருந்து உடல் நீர் நிறை அளவீடுகளை Webhook-க்கு அனுப்பி நீரேற்றம் மற்றும் உடல் அமைப்பைக் கண்காணிக்கவும்.</string>
     <string name="dt_vo2_name">VO₂ அதிகபட்சம்</string>
     <string name="dt_vo2_rationale">VO₂ max அளவுகளை அனுப்பி உங்களின் பயிற்சி முறை மூலம் ஏரோபிக் உடற்திறன் மேம்பாடுகளை அறிந்துகொள்ளக் கண்காணிக்கிறது.</string>
     <string name="dt_bone_name">எலும்பு நிறை</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -86,6 +86,8 @@
     <string name="dt_bf_rationale">将收集在体的人员各项脂质存量比重交由其专属服务器平台监管掌握自身长时间以内的健身表现的变化。</string>
     <string name="dt_lbm_name">瘦体重</string>
     <string name="dt_lbm_rationale">把自身的精瘦等去脂质量读写转进个人的分析口借以检测使用主体本身的增减肌成效或指导相关重构体质锻炼方法。</string>
+    <string name="dt_bwm_name">身体水分质量</string>
+    <string name="dt_bwm_rationale">将智能体重秤的身体水分质量测量发送到您的 webhook，以跟踪水分状态和身体成分。</string>
     <string name="dt_vo2_name">最大摄氧量</string>
     <string name="dt_vo2_rationale">借助向个人的处理接口发送最高带氧指标（VO₂ max）使之能够在监控下准确评估自己各项耐力或持久能力等核心方向的发展程度。</string>
     <string name="dt_bone_name">骨量</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="dt_bf_rationale">Forward body fat percentage measurements to your webhook to track body composition changes and fitness progress over time.</string>
     <string name="dt_lbm_name">Lean Body Mass</string>
     <string name="dt_lbm_rationale">Send lean mass data to your webhook to monitor muscle gain or loss and support body recomposition tracking workflows.</string>
+    <string name="dt_bwm_name">Body Water Mass</string>
+    <string name="dt_bwm_rationale">Forward body water mass measurements to your webhook to track hydration and body composition from smart scales.</string>
     <string name="dt_vo2_name">VO₂ Max</string>
     <string name="dt_vo2_rationale">Forward VO₂ max readings to your webhook to track aerobic fitness improvements, training load, and endurance progress.</string>
     <string name="dt_bone_name">Bone Mass</string>


### PR DESCRIPTION
## Summary
- Add `BODY_WATER_MASS` Health Connect type end-to-end (`body_water_mass` in webhook JSON)
- Compute top-level `bmi` from weight + nearest height when both are present
- Addresses [FeedbackJar: Include body composition in data pull](https://feedback.hcwebhook.com/posts/include-body-composition-in-data-pull/cmrwl7z850005cwf2i65h35xh)

## Test plan
- [ ] Enable Body Water Mass, grant the new Health Connect permission, sync
- [ ] Confirm `body_water_mass` appears when Health Connect has records
- [ ] Enable Weight + Height, sync, confirm `bmi` array with `value`, `weight_kg`, `height_meters`
- [ ] Confirm BMI is omitted when weight or height is missing
- [ ] Note: Samsung/InBody may not write body water into Health Connect even when other metrics sync