### PR TITLE
✨ feat(feedback): implement weekly feedback prompt and related preferences management

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-01-10T06:32:12.757949Z">
+        <DropdownSelection timestamp="2026-08-26T15:31:59.917497Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=2B101JEGR04142" />

--- a/app/src/main/java/com/hcwebhook/app/PreferencesManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/PreferencesManager.kt
@@ -50,6 +50,9 @@ class PreferencesManager(context: Context) {
         private const val KEY_BATTERY_BANNER_DISMISSED = "battery_banner_dismissed"
         private const val KEY_MAX_LOGS = "max_logs"
         private const val KEY_LOCAL_FEEDBACK = "local_feedback"
+        private const val KEY_FIRST_OPEN_TIME = "first_open_time"
+        private const val KEY_WEEKLY_FEEDBACK_PROMPT_DISMISSED = "weekly_feedback_prompt_dismissed"
+        private const val WEEKLY_FEEDBACK_PROMPT_MS = 7L * 24 * 60 * 60 * 1000
         val MAX_LOG_OPTIONS = listOf(50, 100, 500)
         private const val DEFAULT_MAX_LOGS = 100
         private const val MAX_LOCAL_FEEDBACK = 50
@@ -523,5 +526,30 @@ class PreferencesManager(context: Context) {
     fun addLocalFeedback(entry: LocalFeedbackEntry) {
         val updated = (listOf(entry) + getLocalFeedback()).take(MAX_LOCAL_FEEDBACK)
         prefs.edit().putString(KEY_LOCAL_FEEDBACK, Json.encodeToString(updated)).apply()
+    }
+
+    fun ensureFirstOpenTime() {
+        if (!prefs.contains(KEY_FIRST_OPEN_TIME)) {
+            prefs.edit().putLong(KEY_FIRST_OPEN_TIME, System.currentTimeMillis()).apply()
+        }
+    }
+
+    fun shouldShowWeeklyFeedbackPrompt(): Boolean {
+        ensureFirstOpenTime()
+        if (prefs.getBoolean(KEY_WEEKLY_FEEDBACK_PROMPT_DISMISSED, false)) return false
+        val firstOpen = prefs.getLong(KEY_FIRST_OPEN_TIME, System.currentTimeMillis())
+        return System.currentTimeMillis() - firstOpen >= WEEKLY_FEEDBACK_PROMPT_MS
+    }
+
+    fun setWeeklyFeedbackPromptDismissed(dismissed: Boolean) {
+        prefs.edit().putBoolean(KEY_WEEKLY_FEEDBACK_PROMPT_DISMISSED, dismissed).apply()
+    }
+
+    /** Debug only: backdate first open and clear dismiss so the weekly Home card shows. */
+    fun debugForceWeeklyFeedbackPrompt() {
+        prefs.edit()
+            .putLong(KEY_FIRST_OPEN_TIME, System.currentTimeMillis() - WEEKLY_FEEDBACK_PROMPT_MS - 1_000L)
+            .putBoolean(KEY_WEEKLY_FEEDBACK_PROMPT_DISMISSED, false)
+            .apply()
     }
 }

--- a/app/src/main/java/com/hcwebhook/app/screens/AboutScreen.kt
+++ b/app/src/main/java/com/hcwebhook/app/screens/AboutScreen.kt
@@ -2,8 +2,11 @@ package com.hcwebhook.app.screens
 
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -24,7 +27,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.hcwebhook.app.BuildConfig
 import com.hcwebhook.app.FlavorUtils
+import com.hcwebhook.app.PreferencesManager
 import com.hcwebhook.app.R
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Code
@@ -40,7 +45,7 @@ import com.hcwebhook.app.ui.theme.IconTintGreen
 import com.hcwebhook.app.ui.theme.IconTintPurple
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun AboutScreen(
     onRestartOnboarding: () -> Unit = {},
@@ -50,6 +55,7 @@ fun AboutScreen(
     onOpenChangelog: () -> Unit = {},
 ) {
     val context = LocalContext.current
+    val preferencesManager = remember { PreferencesManager(context) }
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     var showFeedbackSheet by remember { mutableStateOf(false) }
@@ -83,6 +89,23 @@ fun AboutScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .then(
+                            if (BuildConfig.DEBUG) {
+                                Modifier.combinedClickable(
+                                    onClick = {},
+                                    onLongClick = {
+                                        preferencesManager.debugForceWeeklyFeedbackPrompt()
+                                        Toast.makeText(
+                                            context,
+                                            context.getString(R.string.feedback_weekly_debug_forced),
+                                            Toast.LENGTH_SHORT,
+                                        ).show()
+                                    },
+                                )
+                            } else {
+                                Modifier
+                            },
+                        )
                         .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {

--- a/app/src/main/java/com/hcwebhook/app/screens/ConfigurationScreen.kt
+++ b/app/src/main/java/com/hcwebhook/app/screens/ConfigurationScreen.kt
@@ -22,10 +22,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Android
@@ -91,6 +93,16 @@ fun ConfigurationScreen(
     var batteryBannerDismissed by remember { mutableStateOf(preferencesManager.isBatteryBannerDismissed()) }
     val showBatteryBanner = isBatteryOptimized && !batteryBannerDismissed
 
+    var showDataTypesSheet by remember { mutableStateOf(false) }
+    var showPermissionsSheet by remember { mutableStateOf(false) }
+    var showFeedbackSheet by remember { mutableStateOf(false) }
+    var showWeeklyFeedbackPrompt by remember {
+        mutableStateOf(preferencesManager.shouldShowWeeklyFeedbackPrompt())
+    }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val feedbackSuccessMessage = stringResource(R.string.feedback_success)
+    val scope = rememberCoroutineScope()
+
     // Re-check battery optimization status every time the user returns to the app
     // (e.g. after granting the exemption in the system dialog).
     DisposableEffect(activity) {
@@ -98,6 +110,7 @@ fun ConfigurationScreen(
             if (event == Lifecycle.Event.ON_RESUME) {
                 val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
                 isBatteryOptimized = !pm.isIgnoringBatteryOptimizations(context.packageName)
+                showWeeklyFeedbackPrompt = preferencesManager.shouldShowWeeklyFeedbackPrompt()
             }
         }
         activity.lifecycle.addObserver(observer)
@@ -107,8 +120,10 @@ fun ConfigurationScreen(
     val oemDeepLinkIntent = remember { BatteryOptimizationHelper.buildOemDeepLinkIntent() }
     val oemLabel = remember { BatteryOptimizationHelper.oemDeepLinkLabel() }
 
-    var showDataTypesSheet by remember { mutableStateOf(false) }
-    var showPermissionsSheet by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        preferencesManager.ensureFirstOpenTime()
+        showWeeklyFeedbackPrompt = preferencesManager.shouldShowWeeklyFeedbackPrompt()
+    }
 
     var lastSyncTime by remember { mutableStateOf(preferencesManager.getLastSyncTime()) }
     var lastSyncSummary by remember { mutableStateOf(preferencesManager.getLastSyncSummary()) }
@@ -176,6 +191,7 @@ fun ConfigurationScreen(
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         floatingActionButton = {
             if (missingPermissionsForEnabled.isNotEmpty()) {
                 ExtendedFloatingActionButton(
@@ -250,6 +266,73 @@ fun ConfigurationScreen(
                             tint = Color(0xFF4CAF50),
                             modifier = Modifier.size(20.dp),
                         )
+                    }
+                }
+            }
+
+            // ── Weekly feedback prompt (after 7 days, until dismissed) ────────
+            if (showWeeklyFeedbackPrompt) {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(44.dp)
+                                    .clip(CircleShape)
+                                    .background(IconBackgroundPurple),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.Chat,
+                                    contentDescription = null,
+                                    tint = IconTintPurple,
+                                    modifier = Modifier.size(22.dp),
+                                )
+                            }
+                            Text(
+                                text = stringResource(R.string.feedback_weekly_title),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text(
+                            text = stringResource(R.string.feedback_weekly_desc),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                        Spacer(modifier = Modifier.height(14.dp))
+                        Button(
+                            onClick = { showFeedbackSheet = true },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(stringResource(R.string.feedback_weekly_cta))
+                        }
+                        TextButton(
+                            onClick = {
+                                showWeeklyFeedbackPrompt = false
+                                preferencesManager.setWeeklyFeedbackPromptDismissed(true)
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.feedback_weekly_dismiss_hint),
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(stringResource(R.string.feedback_weekly_dismiss))
+                        }
                     }
                 }
             }
@@ -735,6 +818,21 @@ fun ConfigurationScreen(
                 }
             )
         }
+
+        FeedbackSheet(
+            visible = showFeedbackSheet,
+            onDismiss = { showFeedbackSheet = false },
+            onSubmitted = {
+                showFeedbackSheet = false
+                if (showWeeklyFeedbackPrompt) {
+                    showWeeklyFeedbackPrompt = false
+                    preferencesManager.setWeeklyFeedbackPromptDismissed(true)
+                }
+                scope.launch {
+                    snackbarHostState.showSnackbar(feedbackSuccessMessage)
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect an Webhook</string>
     <string name="onboarding_welcome_subtitle">Leiten Sie Ihre Gesundheitsdaten automatisch an einen beliebigen Webhook weiter.</string>
     <string name="onboarding_thank_you">Danke für Ihre Unterstützung!</string>
-    <string name="onboarding_thank_you_title">Vielen Dank!</string>
-    <string name="onboarding_thank_you_desc">Ihre Unterstützung hilft dabei, diese App am Leben zu erhalten und zu verbessern. Viel Spaß beim Synchronisieren Ihrer Gesundheitsdaten!</string>
+    <string name="onboarding_thank_you_title">Sie sind startklar!</string>
+    <string name="onboarding_thank_you_desc">Richten Sie Ihre Webhooks ein und starten Sie die Synchronisierung. Wenn etwas nicht funktioniert oder Sie eine neue Funktion brauchen, öffnen Sie Einstellungen → Feedback geben.</string>
     
     <string name="onboarding_feature1_title">Sie entscheiden, was synchronisiert wird</string>
     <string name="onboarding_feature1_desc">Wählen Sie nur die Gesundheitsdaten aus, die Sie weiterleiten möchten.</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">Ihre Daten werden direkt an Ihre URLs gesendet – nirgendwohin sonst</string>
     <string name="onboarding_privacy_p4">Es wird nichts auf externen Servern gespeichert</string>
     <string name="onboarding_privacy_p5">Ihre Daten werden niemals verkauft oder geteilt</string>
-    <string name="onboarding_privacy_footer">Haben Sie Feedback? Gehen Sie jederzeit zum Einstellungen-Tab – wir würden uns freuen, von Ihnen zu hören.</string>
+    <string name="onboarding_privacy_footer">Haben Sie Feedback oder Vorschläge? Öffnen Sie jederzeit den Tab Einstellungen und tippen Sie auf Feedback geben.</string>
     <string name="onboarding_privacy_warning_title">Nur die offizielle Version verwenden</string>
     <string name="onboarding_privacy_warning_desc">Modifizierte Versionen dieser App könnten Ihre Daten stehlen. Laden Sie immer nur von Google Play herunter.</string>
     <string name="medical_disclaimer_title">Diese App ist kein Medizinprodukt</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">Zu viele Einreichungen. Bitte warten Sie ein paar Minuten.</string>
     <string name="feedback_history_title">Ihre Einreichungen</string>
     <string name="feedback_view_all">Alle Funktionsanfragen anzeigen</string>
+    <string name="feedback_weekly_title">Wir brauchen Ihr Feedback</string>
+    <string name="feedback_weekly_desc">Sie nutzen HC Webhook seit einer Woche. Sagen Sie uns, was nicht funktioniert, was fehlt oder was die Synchronisierung besser machen würde. Das dauert etwa eine Minute.</string>
+    <string name="feedback_weekly_cta">Jetzt Feedback senden</string>
+    <string name="feedback_weekly_dismiss">Schließen</string>
+    <string name="feedback_weekly_dismiss_hint">Feedback können Sie jederzeit unter Einstellungen → Feedback geben senden.</string>
+    <string name="feedback_weekly_debug_forced">Wochen-Feedback-Karte freigeschaltet. Öffnen Sie Start, um sie zu sehen.</string>
     <string name="about_link_intro">Einführung ansehen</string>
     <string name="about_link_changelog">Neuigkeiten</string>
     <string name="about_link_changelog_desc">Versionsverlauf und Updates</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect a Webhook</string>
     <string name="onboarding_welcome_subtitle">Reenvía tus datos de salud a cualquier webhook de forma automática.</string>
     <string name="onboarding_thank_you">¡Gracias por su apoyo!</string>
-    <string name="onboarding_thank_you_title">¡Gracias!</string>
-    <string name="onboarding_thank_you_desc">Su apoyo ayuda a mantener esta aplicación viva y en mejora. ¡Disfrute sincronizando sus datos de salud!</string>
+    <string name="onboarding_thank_you_title">¡Todo listo!</string>
+    <string name="onboarding_thank_you_desc">Configura tus webhooks y empieza a sincronizar. Si algo falla o quieres una función nueva, abre Configuración → Proporcionar comentarios.</string>
     
     <string name="onboarding_feature1_title">Tú eliges qué sincronizar</string>
     <string name="onboarding_feature1_desc">Selecciona solo los tipos de datos de salud que deseas reenviar.</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">Tus datos se envían directamente a tus propias URL de webhook, a ningún otro lugar</string>
     <string name="onboarding_privacy_p4">No se almacena nada en ningún servidor externo</string>
     <string name="onboarding_privacy_p5">Tus datos nunca se venden ni se comparten con nadie</string>
-    <string name="onboarding_privacy_footer">¿Tienes comentarios o sugerencias? Ve a la pestaña Configuración en cualquier momento: nos encantaría escucharte.</string>
+    <string name="onboarding_privacy_footer">¿Tienes comentarios o sugerencias? Abre la pestaña Configuración en cualquier momento y toca Proporcionar comentarios.</string>
     <string name="onboarding_privacy_warning_title">Usa solo la versión oficial</string>
     <string name="onboarding_privacy_warning_desc">Las versiones no oficiales o modificadas de esta aplicación pueden robar tus URL de webhook o enviar tus datos de salud a servidores desconocidos. Descarga siempre desde Google Play.</string>
     <string name="medical_disclaimer_title">Esta app no es un dispositivo médico</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">Demasiados envíos. Espera unos minutos.</string>
     <string name="feedback_history_title">Tus envíos</string>
     <string name="feedback_view_all">Ver todas las solicitudes de funciones</string>
+    <string name="feedback_weekly_title">Necesitamos tus comentarios</string>
+    <string name="feedback_weekly_desc">Llevas una semana usando HC Webhook. Cuéntanos qué falló, qué falta o qué mejoraría la sincronización. Solo tarda un minuto.</string>
+    <string name="feedback_weekly_cta">Enviar comentarios ahora</string>
+    <string name="feedback_weekly_dismiss">Descartar</string>
+    <string name="feedback_weekly_dismiss_hint">Puedes enviar comentarios en cualquier momento desde Configuración → Proporcionar comentarios.</string>
+    <string name="feedback_weekly_debug_forced">Tarjeta de comentarios semanal desbloqueada. Abre Inicio para verla.</string>
     <string name="about_link_intro">Ver introducción</string>
     <string name="about_link_changelog">Novedades</string>
     <string name="about_link_changelog_desc">Historial de versiones y actualizaciones</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect vers Webhook</string>
     <string name="onboarding_welcome_subtitle">Transférez automatiquement vos données de santé vers n’importe quel webhook.</string>
     <string name="onboarding_thank_you">Merci pour votre soutien !</string>
-    <string name="onboarding_thank_you_title">Merci !</string>
-    <string name="onboarding_thank_you_desc">Votre soutien aide à maintenir cette application vivante et en amélioration. Profitez de la synchronisation de vos données de santé !</string>
+    <string name="onboarding_thank_you_title">Vous êtes prêt !</string>
+    <string name="onboarding_thank_you_desc">Configurez vos webhooks et lancez la synchronisation. Si quelque chose ne marche pas ou si vous voulez une nouvelle fonction, ouvrez Paramètres → Fournir des commentaires.</string>
     
     <string name="onboarding_feature1_title">Vous choisissez quoi synchroniser</string>
     <string name="onboarding_feature1_desc">Sélectionnez uniquement les types de données de santé que vous souhaitez transférer.</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">Vos données sont envoyées directement à vos propres URL webhook - nulle part ailleurs</string>
     <string name="onboarding_privacy_p4">Rien n’est stocké sur un serveur externe</string>
     <string name="onboarding_privacy_p5">Vos données ne sont jamais vendues ou partagées avec quiconque</string>
-   <string name="onboarding_privacy_footer">Vous avez des commentaires ou des suggestions ? Allez dans l\'onglet Paramètres à tout moment — nous serions ravis de vous entendre.</string>
+   <string name="onboarding_privacy_footer">Vous avez des commentaires ou des suggestions ? Ouvrez l\'onglet Paramètres à tout moment et appuyez sur Fournir des commentaires.</string>
     <string name="onboarding_privacy_warning_title">N\'utilisez que la version officielle</string>
     <string name="onboarding_privacy_warning_desc">Les versions piratées ou modifiées de cette application peuvent voler vos URL webhook ou envoyer vos données de santé à des serveurs inconnus. Téléchargez toujours depuis Google Play.</string>
     <string name="medical_disclaimer_title">Cette app n\'est pas un dispositif médical</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">Trop de soumissions. Veuillez patienter quelques minutes.</string>
     <string name="feedback_history_title">Vos soumissions</string>
     <string name="feedback_view_all">Voir toutes les demandes de fonctionnalités</string>
+    <string name="feedback_weekly_title">Nous avons besoin de vos commentaires</string>
+    <string name="feedback_weekly_desc">Vous utilisez HC Webhook depuis une semaine. Dites-nous ce qui ne fonctionne pas, ce qui manque ou ce qui améliorerait la synchronisation. Cela prend environ une minute.</string>
+    <string name="feedback_weekly_cta">Envoyer un commentaire maintenant</string>
+    <string name="feedback_weekly_dismiss">Ignorer</string>
+    <string name="feedback_weekly_dismiss_hint">Vous pouvez envoyer un commentaire à tout moment depuis Paramètres → Fournir des commentaires.</string>
+    <string name="feedback_weekly_debug_forced">Carte de commentaires hebdomadaire débloquée. Ouvrez Accueil pour la voir.</string>
     <string name="about_link_intro">Voir l\'introduction</string>
     <string name="about_link_changelog">Nouveautés</string>
     <string name="about_link_changelog_desc">Historique des versions et mises à jour</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect verso Webhook</string>
     <string name="onboarding_welcome_subtitle">Inoltra automaticamente i tuoi dati sanitari a qualsiasi webhook.</string>
     <string name="onboarding_thank_you">Grazie per il tuo supporto!</string>
-    <string name="onboarding_thank_you_title">Grazie!</string>
-    <string name="onboarding_thank_you_desc">Il tuo supporto aiuta a mantenere questa app attiva e in miglioramento. Goditi la sincronizzazione dei tuoi dati sanitari!</string>
+    <string name="onboarding_thank_you_title">Tutto pronto!</string>
+    <string name="onboarding_thank_you_desc">Configura i webhook e avvia la sincronizzazione. Se qualcosa non funziona o vuoi una nuova funzione, apri Impostazioni → Fornire feedback.</string>
     
     <string name="onboarding_feature1_title">Scegli cosa sincronizzare</string>
     <string name="onboarding_feature1_desc">Seleziona solo i tipi di dati sanitari che desideri inoltrare.</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">I tuoi dati vengono inviati direttamente agli URL webhook configurati — in nessun altro posto</string>
     <string name="onboarding_privacy_p4">Niente viene archiviato su server esterni</string>
     <string name="onboarding_privacy_p5">I tuoi dati non vengono mai venduti o condivisi con nessuno</string>
-    <string name="onboarding_privacy_footer">Hai feedback o suggerimenti? Vai alla scheda Impostazioni in qualsiasi momento: ci piacerebbe ascoltarti.</string>
+    <string name="onboarding_privacy_footer">Hai feedback o suggerimenti? Apri in qualsiasi momento la scheda Impostazioni e tocca Fornire feedback.</string>
     <string name="onboarding_privacy_warning_title">Usa solo la versione ufficiale</string>
     <string name="onboarding_privacy_warning_desc">Le versioni craccate o modificate di questa app possono rubare i tuoi URL webhook o inviare i tuoi dati sanitari a server sconosciuti. Scarica sempre da Google Play.</string>
     <string name="medical_disclaimer_title">Questa app non è un dispositivo medico</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">Troppe invii. Attendi qualche minuto.</string>
     <string name="feedback_history_title">I tuoi invii</string>
     <string name="feedback_view_all">Visualizza tutte le richieste di funzionalità</string>
+    <string name="feedback_weekly_title">Abbiamo bisogno del tuo feedback</string>
+    <string name="feedback_weekly_desc">Usi HC Webhook da una settimana. Dicci cosa non funziona, cosa manca o cosa migliorerebbe la sincronizzazione. Ci vuole circa un minuto.</string>
+    <string name="feedback_weekly_cta">Invia feedback ora</string>
+    <string name="feedback_weekly_dismiss">Ignora</string>
+    <string name="feedback_weekly_dismiss_hint">Puoi inviare feedback in qualsiasi momento da Impostazioni → Fornire feedback.</string>
+    <string name="feedback_weekly_debug_forced">Scheda feedback settimanale sbloccata. Apri Home per vederla.</string>
     <string name="about_link_intro">Visualizza l\'introduzione</string>
     <string name="about_link_changelog">Novità</string>
     <string name="about_link_changelog_desc">Cronologia versioni e aggiornamenti</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect から Webhook へ</string>
     <string name="onboarding_welcome_subtitle">健康データを任意の Webhook に自動的に転送します。</string>
     <string name="onboarding_thank_you">ご支援ありがとうございます！</string>
-    <string name="onboarding_thank_you_title">ありがとうございます！</string>
-    <string name="onboarding_thank_you_desc">あなたのサポートがこのアプリの継続と改善を支えています。健康データの同期をお楽しみください！</string>
+    <string name="onboarding_thank_you_title">準備完了です！</string>
+    <string name="onboarding_thank_you_desc">Webhook を設定して同期を開始してください。不具合や新機能の要望がある場合は、「設定」→「フィードバックを提供する」を開いてください。</string>
     
     <string name="onboarding_feature1_title">同期するデータを選択できます</string>
     <string name="onboarding_feature1_desc">転送したい健康データの種類だけを選択してください。</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">データは設定されたWebhook URLに直接送信され、他の場所には送信されません。</string>
     <string name="onboarding_privacy_p4">外部サーバーには一切保存されません。</string>
     <string name="onboarding_privacy_p5">あなたのデータが販売されたり他者と共有されることはありません。</string>
-    <string name="onboarding_privacy_footer">ご意見やご提案がありましたら、いつでも「設定」タブからお知らせください。</string>
+    <string name="onboarding_privacy_footer">ご意見やご提案がありましたら、いつでも「設定」タブを開き、「フィードバックを提供する」をタップしてください。</string>
     <string name="onboarding_privacy_warning_title">公式版のみを使用してください</string>
     <string name="onboarding_privacy_warning_desc">このアプリの不正改造版などは、Webhook URLを盗んだり、健康データを未知のサーバーに送信するおそれがあります。必ずGoogle Playからダウンロードしてください。</string>
     <string name="medical_disclaimer_title">このアプリは医療機器ではありません</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">送信回数が多すぎます。数分お待ちください。</string>
     <string name="feedback_history_title">送信履歴</string>
     <string name="feedback_view_all">すべての機能リクエストを見る</string>
+    <string name="feedback_weekly_title">フィードバックをお願いします</string>
+    <string name="feedback_weekly_desc">HC Webhook を1週間お使いです。不具合、不足している点、同期を良くする方法を教えてください。約1分で送れます。</string>
+    <string name="feedback_weekly_cta">今すぐフィードバックを送る</string>
+    <string name="feedback_weekly_dismiss">閉じる</string>
+    <string name="feedback_weekly_dismiss_hint">フィードバックはいつでも「設定」→「フィードバックを提供する」から送れます。</string>
+    <string name="feedback_weekly_debug_forced">週次フィードバックカードを解除しました。ホームを開いて確認してください。</string>
     <string name="about_link_intro">概要を見る</string>
     <string name="about_link_changelog">新機能</string>
     <string name="about_link_changelog_desc">リリース履歴とアップデート</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect에서 Webhook으로</string>
     <string name="onboarding_welcome_subtitle">건강 데이터를 모든 웹훅에 자동으로 전달합니다.</string>
     <string name="onboarding_thank_you">지원해 주셔서 감사합니다!</string>
-    <string name="onboarding_thank_you_title">감사합니다!</string>
-    <string name="onboarding_thank_you_desc">여러분의 지원 덕분에 이 앱이 계속 발전할 수 있습니다. 건강 데이터 동기화를 즐기세요!</string>
+    <string name="onboarding_thank_you_title">준비 완료!</string>
+    <string name="onboarding_thank_you_desc">웹훅을 설정하고 동기화를 시작하세요. 문제가 있거나 새 기능이 필요하면 설정 → 피드백 제공을 여세요.</string>
     
     <string name="onboarding_feature1_title">동기화할 내용 선택</string>
     <string name="onboarding_feature1_desc">전달할 건강 데이터 유형만 선택하세요.</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">데이터는 구성된 웹훅 URL로만 직접 전송되며 다른 곳으로는 전송되지 않습니다.</string>
     <string name="onboarding_privacy_p4">외부 서버에 어떠한 데이터도 저장되지 않습니다.</string>
     <string name="onboarding_privacy_p5">사용자의 데이터는 제3자에게 판매되거나 공유되지 않습니다.</string>
-    <string name="onboarding_privacy_footer">의견이나 제안 사항이 있으신가요? 언제든지 ’설정’ 탭을 방문하여 알려주세요.</string>
+    <string name="onboarding_privacy_footer">의견이나 제안이 있으신가요? 언제든지 설정 탭을 열고 피드백 제공을 탭하세요.</string>
     <string name="onboarding_privacy_warning_title">공식 버전만 사용하세요</string>
     <string name="onboarding_privacy_warning_desc">앱을 무단으로 변경한 버전은 웹훅 URL을 훔치거나 알 수 없는 서버로 모바일 건강 데이터를 전송할 수 있습니다. 항상 Google Play에서 다운로드하세요.</string>
     <string name="medical_disclaimer_title">이 앱은 의료기기가 아닙니다</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">제출 횟수가 너무 많습니다. 몇 분 후에 다시 시도해 주세요.</string>
     <string name="feedback_history_title">제출 내역</string>
     <string name="feedback_view_all">모든 기능 요청 보기</string>
+    <string name="feedback_weekly_title">피드백이 필요합니다</string>
+    <string name="feedback_weekly_desc">HC Webhook을 일주일 동안 사용하셨습니다. 무엇이 고장 났는지, 무엇이 부족한지, 동기화를 어떻게 개선하면 좋을지 알려 주세요. 약 1분이면 됩니다.</string>
+    <string name="feedback_weekly_cta">지금 피드백 보내기</string>
+    <string name="feedback_weekly_dismiss">닫기</string>
+    <string name="feedback_weekly_dismiss_hint">피드백은 언제든지 설정 → 피드백 제공에서 보낼 수 있습니다.</string>
+    <string name="feedback_weekly_debug_forced">주간 피드백 카드가 잠금 해제되었습니다. 홈에서 확인하세요.</string>
     <string name="about_link_intro">소개 보기</string>
     <string name="about_link_changelog">새로운 기능</string>
     <string name="about_link_changelog_desc">릴리스 기록 및 업데이트</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect para Webhook</string>
     <string name="onboarding_welcome_subtitle">Encaminhe seus dados de saúde para qualquer webhook — automaticamente.</string>
     <string name="onboarding_thank_you">Obrigado pelo seu apoio!</string>
-    <string name="onboarding_thank_you_title">Obrigado!</string>
-    <string name="onboarding_thank_you_desc">Seu apoio ajuda a manter este aplicativo vivo e em melhoria. Aproveite a sincronização dos seus dados de saúde!</string>
+    <string name="onboarding_thank_you_title">Tudo pronto!</string>
+    <string name="onboarding_thank_you_desc">Configure seus webhooks e comece a sincronizar. Se algo falhar ou você quiser um novo recurso, abra Configurações → Fornecer comentários.</string>
     
     <string name="onboarding_feature1_title">Você escolhe o que sincronizar</string>
     <string name="onboarding_feature1_desc">Selecione apenas os tipos de dados de saúde que deseja encaminhar.</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">Seus dados são enviados diretamente para seus próprios URLs de webhook — para nenhum outro lugar</string>
     <string name="onboarding_privacy_p4">Nada é armazenado em nenhum servidor externo</string>
     <string name="onboarding_privacy_p5">Seus dados nunca são vendidos ou compartilhados com ninguém</string>
-    <string name="onboarding_privacy_footer">Tem comentários ou sugestões? Acesse a guia Configurações a qualquer momento — adoraríamos ouvi-lo.</string>
+    <string name="onboarding_privacy_footer">Tem comentários ou sugestões? Abra a guia Configurações a qualquer momento e toque em Fornecer comentários.</string>
     <string name="onboarding_privacy_warning_title">Use apenas a versão oficial</string>
     <string name="onboarding_privacy_warning_desc">Versões piratas ou modificadas deste aplicativo podem roubar seus URLs de webhook ou enviar seus dados de saúde para servidores desconhecidos. Baixe sempre do Google Play.</string>
     <string name="medical_disclaimer_title">Este app não é um dispositivo médico</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">Muitos envios. Aguarde alguns minutos.</string>
     <string name="feedback_history_title">Seus envios</string>
     <string name="feedback_view_all">Ver todas as solicitações de recursos</string>
+    <string name="feedback_weekly_title">Precisamos do seu feedback</string>
+    <string name="feedback_weekly_desc">Você usa o HC Webhook há uma semana. Diga o que quebrou, o que falta ou o que melhoraria a sincronização. Leva cerca de um minuto.</string>
+    <string name="feedback_weekly_cta">Enviar feedback agora</string>
+    <string name="feedback_weekly_dismiss">Dispensar</string>
+    <string name="feedback_weekly_dismiss_hint">Você pode enviar feedback a qualquer momento em Configurações → Fornecer comentários.</string>
+    <string name="feedback_weekly_debug_forced">Cartão de feedback semanal desbloqueado. Abra Início para vê-lo.</string>
     <string name="about_link_intro">Ver introdução</string>
     <string name="about_link_changelog">Novidades</string>
     <string name="about_link_changelog_desc">Histórico de versões e atualizações</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect லிருந்து Webhook க்கு</string>
     <string name="onboarding_welcome_subtitle">உங்கள் சுகாதாரத் தரவை எந்தவொரு webhook-க்கும் தானாகவே பகிரவும்.</string>
     <string name="onboarding_thank_you">உங்கள் ஆதரவிற்கு நன்றி!</string>
-    <string name="onboarding_thank_you_title">நன்றி!</string>
-    <string name="onboarding_thank_you_desc">உங்கள் ஆதரவு இந்த பயன்பாட்டை தொடர்ந்து வளர்க்க உதவுகிறது. உங்கள் உடல்நல தரவை ஒத்திசைக்க மகிழுங்கள்!</string>
+    <string name="onboarding_thank_you_title">தயார்!</string>
+    <string name="onboarding_thank_you_desc">உங்கள் webhook-களை அமைத்து ஒத்திசைவைத் தொடங்குங்கள். ஏதேனும் பிழை இருந்தாலோ அல்லது புதிய அம்சம் வேண்டுமானாலோ, அமைப்புகள் → கருத்துக்களை வழங்கவும் என்பதைத் திறக்கவும்.</string>
     
     <string name="onboarding_feature1_title">நீங்கள் பகிர விரும்புவதை நீங்களே தேர்வு செய்யலாம்</string>
     <string name="onboarding_feature1_desc">நீங்கள் பகிர விரும்பும் சுகாதார தரவு வகைகளை மட்டும் தேர்ந்தெடுக்கவும்.</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">உங்கள் தரவு நேரடியாக உங்கள் webhook URL-களுக்கு மட்டுமே அனுப்பப்படும் — வேறு எங்கும் இல்லை</string>
     <string name="onboarding_privacy_p4">எந்த வெளி சர்வரிலும் எதுவும் சேமிக்கப்படுவதில்லை</string>
     <string name="onboarding_privacy_p5">உங்கள் தரவு ஒருபோதும் விற்கப்படுவதில்லை</string>
-    <string name="onboarding_privacy_footer">கருத்து அல்லது பரிந்துரைகள் உள்ளதா? அமைப்புகள் தாவலுக்கு எப்போது வேண்டுமானாலும் செல்லவும் — உங்களோடு பேச ஆர்வமாக உள்ளோம்.</string>
+    <string name="onboarding_privacy_footer">கருத்து அல்லது பரிந்துரைகள் உள்ளதா? எப்போது வேண்டுமானாலும் அமைப்புகள் தாவலைத் திறந்து, கருத்துக்களை வழங்கவும் என்பதைத் தட்டவும்.</string>
     <string name="onboarding_privacy_warning_title">அதிகாரப்பூர்வ பதிப்பை மட்டும் பயன்படுத்தவும்</string>
     <string name="onboarding_privacy_warning_desc">இந்த செயலியின் மாற்றியமைக்கப்பட்ட பதிப்புகள் உங்கள் webhook URL-களை திருடலாம் அல்லது உங்கள் சுகாதார தரவை தெரியாத சர்வருக்கு அனுப்பலாம். எப்போதும் Google Play-ல் இருந்து மட்டுமே பதிவிறக்கம் செய்யவும்.</string>
     <string name="medical_disclaimer_title">இந்த செயலி மருத்துவ சாதனம் அல்ல</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">அதிகமான சமர்ப்பிப்புகள். சில நிமிடங்கள் காத்திருக்கவும்.</string>
     <string name="feedback_history_title">உங்கள் சமர்ப்பிப்புகள்</string>
     <string name="feedback_view_all">அனைத்து அம்சக் கோரிக்கைகளையும் பார்க்கவும்</string>
+    <string name="feedback_weekly_title">உங்கள் கருத்து தேவை</string>
+    <string name="feedback_weekly_desc">நீங்கள் HC Webhook-ஐ ஒரு வாரம் பயன்படுத்துகிறீர்கள். என்ன உடைந்தது, என்ன இல்லை, அல்லது ஒத்திசைவை எது மேம்படுத்தும் என்பதைச் சொல்லுங்கள். சுமார் ஒரு நிமிடம் ஆகும்.</string>
+    <string name="feedback_weekly_cta">இப்போது கருத்தை அனுப்பவும்</string>
+    <string name="feedback_weekly_dismiss">மூடு</string>
+    <string name="feedback_weekly_dismiss_hint">கருத்தை எப்போது வேண்டுமானாலும் அமைப்புகள் → கருத்துக்களை வழங்கவும் என்பதிலிருந்து அனுப்பலாம்.</string>
+    <string name="feedback_weekly_debug_forced">வாரக் கருத்து அட்டை திறக்கப்பட்டது. பார்க்க முகப்புக்குச் செல்லவும்.</string>
     <string name="about_link_intro">அறிமுகத்தைப் பார்க்கவும்</string>
     <string name="about_link_changelog">புதியவை</string>
     <string name="about_link_changelog_desc">வெளியீட்டு வரலாறு மற்றும் புதுப்பிப்புகள்</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -11,8 +11,8 @@
     <string name="onboarding_welcome_title">Health Connect 到 Webhook</string>
     <string name="onboarding_welcome_subtitle">自动将您的健康数据转发到任何 webhook。</string>
     <string name="onboarding_thank_you">感谢您的支持！</string>
-    <string name="onboarding_thank_you_title">谢谢！</string>
-    <string name="onboarding_thank_you_desc">您的支持帮助这款应用持续改进。祝您健康数据同步愉快！</string>
+    <string name="onboarding_thank_you_title">一切就绪！</string>
+    <string name="onboarding_thank_you_desc">配置你的 webhook 并开始同步。如果出现问题或想要新功能，请打开设置 → 提供反馈。</string>
     
     <string name="onboarding_feature1_title">您选择要同步的内容</string>
     <string name="onboarding_feature1_desc">仅选择您想要转发的健康数据类型。</string>
@@ -37,7 +37,7 @@
     <string name="onboarding_privacy_p3">您的数据直接发送到您自己的 webhook URL — 不会发往其他地方</string>
     <string name="onboarding_privacy_p4">没有任何数据存储在任何外部服务器上</string>
     <string name="onboarding_privacy_p5">您的数据绝不会出售或与任何人共享</string>
-    <string name="onboarding_privacy_footer">有反馈或建议？欢迎随时前往“设置”标签页 — 我们很乐意收到您的意见。</string>
+    <string name="onboarding_privacy_footer">有反馈或建议？随时打开“设置”标签页，然后点按“提供反馈”。</string>
     <string name="onboarding_privacy_warning_title">仅使用官方版本</string>
     <string name="onboarding_privacy_warning_desc">此应用的破解版或修改版可能会窃取您的 webhook URL 或将您的健康数据发送到未知服务器。请始终从 Google Play 下载。</string>
     <string name="medical_disclaimer_title">本应用不是医疗设备</string>
@@ -254,6 +254,12 @@
     <string name="feedback_rate_limited">提交过于频繁。请稍等几分钟。</string>
     <string name="feedback_history_title">您的提交</string>
     <string name="feedback_view_all">查看所有功能请求</string>
+    <string name="feedback_weekly_title">我们需要你的反馈</string>
+    <string name="feedback_weekly_desc">你已使用 HC Webhook 一周。告诉我们哪里出了问题、还缺什么，或怎样能让同步更好。大约只需一分钟。</string>
+    <string name="feedback_weekly_cta">立即发送反馈</string>
+    <string name="feedback_weekly_dismiss">关闭</string>
+    <string name="feedback_weekly_dismiss_hint">你可以随时在设置 → 提供反馈中发送反馈。</string>
+    <string name="feedback_weekly_debug_forced">已解锁每周反馈卡片。打开主页即可查看。</string>
     <string name="about_link_intro">查看简介</string>
     <string name="about_link_changelog">新功能</string>
     <string name="about_link_changelog_desc">版本历史和更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,8 +10,8 @@
     <string name="onboarding_welcome_title">Health Connect to Webhook</string>
     <string name="onboarding_welcome_subtitle">Forward your health data to any webhook — automatically.</string>
     <string name="onboarding_thank_you">Thank you for your support!</string>
-    <string name="onboarding_thank_you_title">Thank You!</string>
-    <string name="onboarding_thank_you_desc">Your support helps keep this app alive and improving. Enjoy syncing your health data!</string>
+    <string name="onboarding_thank_you_title">You\'re all set!</string>
+    <string name="onboarding_thank_you_desc">Configure your webhooks and start syncing. If something breaks or you want a new feature, open Settings → Provide Feedback.</string>
     
     <string name="onboarding_feature1_title">You choose what to sync</string>
     <string name="onboarding_feature1_desc">Select only the health data types you want to forward.</string>
@@ -36,7 +36,7 @@
     <string name="onboarding_privacy_p3">Your data is sent directly to your own webhook URLs — nowhere else</string>
     <string name="onboarding_privacy_p4">Nothing is stored on any external server</string>
     <string name="onboarding_privacy_p5">Your data is never sold or shared with anyone</string>
-    <string name="onboarding_privacy_footer">Have feedback or suggestions? Head to the Settings tab anytime — we’d love to hear from you.</string>
+    <string name="onboarding_privacy_footer">Have feedback or suggestions? Open the Settings tab anytime and tap Provide Feedback.</string>
     <string name="onboarding_privacy_warning_title">Use only the official version</string>
     <string name="onboarding_privacy_warning_desc">Cracked or modified versions of this app may steal your webhook URLs or send your health data to unknown servers. Always download from Google Play.</string>
     <string name="medical_disclaimer_title">This app is not a medical device</string>
@@ -285,6 +285,12 @@
     <string name="feedback_rate_limited">Too many submissions. Please wait a few minutes.</string>
     <string name="feedback_history_title">Your submissions</string>
     <string name="feedback_view_all">View all feature requests</string>
+    <string name="feedback_weekly_title">We need your feedback</string>
+    <string name="feedback_weekly_desc">You have used HC Webhook for a week. Tell us what broke, what is missing, or what would make sync better. This takes about one minute.</string>
+    <string name="feedback_weekly_cta">Send feedback now</string>
+    <string name="feedback_weekly_dismiss">Dismiss</string>
+    <string name="feedback_weekly_dismiss_hint">You can send feedback anytime from Settings → Provide Feedback.</string>
+    <string name="feedback_weekly_debug_forced">Weekly feedback card unlocked. Open Home to see it.</string>
     <string name="about_link_intro">View Introduction</string>
     <string name="about_link_changelog">What\'s New</string>
     <string name="about_link_changelog_desc">Release history and updates</string>


### PR DESCRIPTION
- Added functionality to prompt users for feedback after one week of usage.
- Introduced new preferences for tracking first open time and feedback prompt dismissal.
- Updated UI to display feedback prompt in ConfigurationScreen and AboutScreen.
- Added debug option to force display of the feedback prompt for testing purposes.
- Updated strings for onboarding and feedback messages in multiple languages.