### PR TITLE
feat(sleep): add sleep_updated_at from SleepSessionRecord metadata

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -236,7 +236,8 @@ data class SleepData(
     val sessionEndTime: Instant,
     val duration: Duration,
     val stages: List<SleepStage>,
-    val metadata: RecordMetadata? = null
+    val metadata: RecordMetadata? = null,
+    val sessionUpdatedAt: Instant? = null
 )
 
 data class SleepStage(
@@ -1092,7 +1093,8 @@ class HealthConnectManager(private val context: Context) {
                     sessionEndTime = record.endTime,
                     duration = Duration.between(record.startTime, record.endTime),
                     stages = stages,
-                    metadata = record.toRecordMetadata(startZoneOffset = record.startZoneOffset, endZoneOffset = record.endZoneOffset)
+                    metadata = record.toRecordMetadata(startZoneOffset = record.startZoneOffset, endZoneOffset = record.endZoneOffset),
+                    sessionUpdatedAt = record.metadata.lastModifiedTime
                 )
             }
     }

--- a/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
+++ b/app/src/main/java/com/hcwebhook/app/MockPayloadBuilder.kt
@@ -55,6 +55,7 @@ object MockPayloadBuilder {
                         add(buildJsonObject {
                             put("session_end_time", sleep.sessionEndTime.toString())
                             put("duration_seconds", sleep.duration.seconds)
+                            sleep.sessionUpdatedAt?.let { put("sleep_updated_at", it.toString()) }
                             putJsonArray("stages") {
                                 sleep.stages.forEach { stage ->
                                     add(buildJsonObject {
@@ -475,7 +476,8 @@ object MockPayloadBuilder {
                         SleepStage("rem", t(2, 0), t(5, 30), Duration.ofSeconds(12600)),
                         SleepStage("light", t(5, 30), t(7, 0), Duration.ofSeconds(5400))
                     ),
-                    metadata = fitnessMeta
+                    metadata = fitnessMeta,
+                    sessionUpdatedAt = t(7, 0)
                 )
             ) else emptyList(),
             heartRate = if (include(HealthDataType.HEART_RATE.name)) {

--- a/app/src/main/java/com/hcwebhook/app/SyncManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/SyncManager.kt
@@ -70,7 +70,7 @@ class SyncManager(private val context: Context) {
             }
 
             val jsonPayload = try {
-                buildJsonPayload(healthDataResult.getOrThrow())
+                buildJsonPayload(healthDataResult.getOrThrow(), appVersionName)
             } catch (oom: OutOfMemoryError) {
                 return@withContext Result.failure(
                     Exception(
@@ -159,7 +159,7 @@ class SyncManager(private val context: Context) {
 
             // Build full payload (also used by local TCP server)
             val fullPayload = try {
-                buildJsonPayload(healthData)
+                buildJsonPayload(healthData, appVersionName)
             } catch (oom: OutOfMemoryError) {
                 return@withContext Result.failure(
                     Exception(
@@ -194,7 +194,7 @@ class SyncManager(private val context: Context) {
                     val result = when (config.deliveryFormat) {
                         WebhookDeliveryFormat.JSON -> {
                             val payload = try {
-                                if (config.dataTypeFilter != null) buildJsonPayload(filteredData) else fullPayload
+                                if (config.dataTypeFilter != null) buildJsonPayload(filteredData, appVersionName) else fullPayload
                             } catch (oom: OutOfMemoryError) {
                                 lastFailure = Exception(
                                     "Out of memory while building JSON for ${config.url}. Raise sample resolution.",
@@ -223,7 +223,7 @@ class SyncManager(private val context: Context) {
                                 continue
                             }
                             val logJson = try {
-                                if (config.dataTypeFilter != null) buildJsonPayload(filteredData) else fullPayload
+                                if (config.dataTypeFilter != null) buildJsonPayload(filteredData, appVersionName) else fullPayload
                             } catch (_: OutOfMemoryError) {
                                 null
                             }
@@ -562,7 +562,14 @@ class SyncManager(private val context: Context) {
         return if (parts.isEmpty()) "No new data" else parts.joinToString(" · ")
     }
 
-    private fun buildJsonPayload(healthData: HealthData): String {
+    companion object {
+        /**
+         * Soft cap before JSON encode. Full-resolution heart rate over 48h can
+         * exceed this and OOMs mid-tier devices while building JsonObject trees.
+         */
+        private const val MAX_RECORDS_PER_PAYLOAD = 25_000
+
+        internal fun buildJsonPayload(healthData: HealthData, appVersionName: String): String {
         val json = buildJsonObject {
             put("timestamp", Instant.now().toString())
             put("app_version", appVersionName)
@@ -586,6 +593,7 @@ class SyncManager(private val context: Context) {
                         add(buildJsonObject {
                             put("session_end_time", sleep.sessionEndTime.toString())
                             put("duration_seconds", sleep.duration.seconds)
+                            sleep.sessionUpdatedAt?.let { put("sleep_updated_at", it.toString()) }
                             putJsonArray("stages") {
                                 sleep.stages.forEach { stage ->
                                     add(buildJsonObject {
@@ -989,39 +997,32 @@ class SyncManager(private val context: Context) {
         return json.toString()
     }
 
-    companion object {
-        /**
-         * Soft cap before JSON encode. Full-resolution heart rate over 48h can
-         * exceed this and OOMs mid-tier devices while building JsonObject trees.
-         */
-        private const val MAX_RECORDS_PER_PAYLOAD = 25_000
-    }
+        private data class BmiEntry(
+            val value: Double,
+            val time: Instant,
+            val weightKg: Double,
+            val heightMeters: Double
+        )
 
-    private data class BmiEntry(
-        val value: Double,
-        val time: Instant,
-        val weightKg: Double,
-        val heightMeters: Double
-    )
-
-    /** BMI = kg / m². Pair each weight with the height record closest in time. */
-    private fun computeBmiEntries(
-        weights: List<WeightData>,
-        heights: List<HeightData>
-    ): List<BmiEntry> {
-        if (weights.isEmpty() || heights.isEmpty()) return emptyList()
-        return weights.mapNotNull { weight ->
-            val height = heights.minByOrNull { h ->
-                kotlin.math.abs(h.time.toEpochMilli() - weight.time.toEpochMilli())
-            } ?: return@mapNotNull null
-            if (height.meters <= 0.0) return@mapNotNull null
-            val bmi = weight.kilograms / (height.meters * height.meters)
-            BmiEntry(
-                value = bmi,
-                time = weight.time,
-                weightKg = weight.kilograms,
-                heightMeters = height.meters
-            )
+        /** BMI = kg / m². Pair each weight with the height record closest in time. */
+        private fun computeBmiEntries(
+            weights: List<WeightData>,
+            heights: List<HeightData>
+        ): List<BmiEntry> {
+            if (weights.isEmpty() || heights.isEmpty()) return emptyList()
+            return weights.mapNotNull { weight ->
+                val height = heights.minByOrNull { h ->
+                    kotlin.math.abs(h.time.toEpochMilli() - weight.time.toEpochMilli())
+                } ?: return@mapNotNull null
+                if (height.meters <= 0.0) return@mapNotNull null
+                val bmi = weight.kilograms / (height.meters * height.meters)
+                BmiEntry(
+                    value = bmi,
+                    time = weight.time,
+                    weightKg = weight.kilograms,
+                    heightMeters = height.meters
+                )
+            }
         }
     }
 }

--- a/app/src/test/java/com/hcwebhook/app/SleepUpdatedAtJsonTest.kt
+++ b/app/src/test/java/com/hcwebhook/app/SleepUpdatedAtJsonTest.kt
@@ -1,0 +1,96 @@
+package com.hcwebhook.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Simulated-data read/write validation for the `sleep_updated_at` field:
+ * the JSON payload must carry the sleep record's last-updated time as ISO 8601,
+ * and must keep working (field omitted) when the value is unavailable.
+ */
+class SleepUpdatedAtJsonTest {
+
+    @Test
+    fun sleepPayload_includesSleepUpdatedAtIso8601() {
+        val t = Instant.parse("2026-05-09T12:00:00Z")
+        val data = emptyHealthData().copy(
+            sleep = listOf(
+                SleepData(
+                    sessionEndTime = t,
+                    duration = Duration.ofSeconds(27000),
+                    stages = listOf(
+                        SleepStage("deep", t.minusSeconds(27000), t.minusSeconds(19800), Duration.ofSeconds(7200))
+                    ),
+                    sessionUpdatedAt = t.plusSeconds(300)
+                )
+            )
+        )
+
+        val json = SyncManager.buildJsonPayload(data, "1.9.19-test")
+
+        // 新字段:ISO 8601,带 Z(UTC)
+        assertTrue(json.contains("\"sleep_updated_at\":\"2026-05-09T12:05:00Z\""))
+        // 原有字段兼容,结构未破坏
+        assertTrue(json.contains("\"session_end_time\":\"2026-05-09T12:00:00Z\""))
+        assertTrue(json.contains("\"duration_seconds\":27000"))
+        assertTrue(json.contains("\"stage\":\"deep\""))
+    }
+
+    @Test
+    fun sleepPayload_omitsSleepUpdatedAtWhenUnavailable() {
+        val t = Instant.parse("2026-05-09T12:00:00Z")
+        val data = emptyHealthData().copy(
+            sleep = listOf(
+                SleepData(
+                    sessionEndTime = t,
+                    duration = Duration.ofSeconds(27000),
+                    stages = emptyList()
+                )
+            )
+        )
+
+        val json = SyncManager.buildJsonPayload(data, "1.9.19-test")
+
+        // 无更新时间时整个字段缺省,老解析器完全无感
+        assertFalse(json.contains("sleep_updated_at"))
+        assertTrue(json.contains("\"duration_seconds\":27000"))
+    }
+
+    private fun emptyHealthData() = HealthData(
+        steps = emptyList(),
+        sleep = emptyList(),
+        heartRate = emptyList(),
+        heartRateVariability = emptyList(),
+        distance = emptyList(),
+        activeCalories = emptyList(),
+        totalCalories = emptyList(),
+        weight = emptyList(),
+        height = emptyList(),
+        bloodPressure = emptyList(),
+        bloodGlucose = emptyList(),
+        oxygenSaturation = emptyList(),
+        bodyTemperature = emptyList(),
+        skinTemperature = emptyList(),
+        respiratoryRate = emptyList(),
+        restingHeartRate = emptyList(),
+        exercise = emptyList(),
+        hydration = emptyList(),
+        nutrition = emptyList(),
+        basalMetabolicRate = emptyList(),
+        bodyFat = emptyList(),
+        leanBodyMass = emptyList(),
+        bodyWaterMass = emptyList(),
+        vo2Max = emptyList(),
+        boneMass = emptyList(),
+        menstruationFlow = emptyList(),
+        menstruationPeriod = emptyList(),
+        intermenstrualBleeding = emptyList(),
+        ovulationTest = emptyList(),
+        cervicalMucus = emptyList(),
+        sexualActivity = emptyList(),
+        basalBodyTemperature = emptyList()
+    )
+}

--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -161,6 +161,7 @@ Keys use **snake_case**. Numeric types follow Kotlin serialization to JSON (e.g.
 |-------|------|-------------|
 | `session_end_time` | string | End of the sleep session. |
 | `duration_seconds` | number (integer) | Total session duration in seconds. |
+| `sleep_updated_at` | string (ISO 8601) | Last time the health platform updated this sleep record (`SleepSessionRecord.metadata.lastModifiedTime`). Omits when unavailable. Useful to tell interim vs finalized values. |
 | `stages` | array | Ordered sleep stages (see below). |
 
 Each **stage** object:


### PR DESCRIPTION
## What

Add a `sleep_updated_at` field to the sleep payload, taken from `SleepSessionRecord.metadata.lastModifiedTime` (ISO 8601, UTC, `Z` suffix).

The band keeps revising a night's sleep for a while after waking. Without this field a mid-morning sync can report an intermediate duration (e.g. 8h37m) that later settles to a different final value, and downstream consumers have no way to tell the two apart. This field exposes the record's last-update time so consumers can distinguish settled data from in-flight revisions.

## Changes

- `HealthConnectManager.kt` — `SleepData` gains `sessionUpdatedAt: Instant? = null`; `readSleepData` fills it from `record.metadata.lastModifiedTime`.
- `SyncManager.kt` — JSON payload emits `"sleep_updated_at"` only when available; field is omitted otherwise, so existing parsers are completely unaffected.
- `MockPayloadBuilder.kt` — mock payload carries a sample timestamp.
- `SleepUpdatedAtJsonTest.kt` — two new unit tests: field present (ISO 8601) / field omitted when unavailable.
- `docs/webhook.md` — one-line documentation of the new field.

## Validation

- Unit tests pass (2/2 green).
- Built a test APK (1.9.19-test) and verified the payload end-to-end.
