### PR TITLE
fix(http-server): label oldest daily bucket with real window start

### DIFF
--- a/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
+++ b/app/src/main/java/com/hcwebhook/app/HealthConnectManager.kt
@@ -1047,7 +1047,11 @@ class HealthConnectManager(private val context: Context) {
             if (daySteps > 0) {
                 result.add(StepsData(
                     count = daySteps,
-                    startTime = dayStart,
+                    // Use the clamped window start, not local midnight: the oldest
+                    // bucket in a lookback window covers only the elapsed part of
+                    // the day, so a midnight start_time would mislabel a partial
+                    // day as a full one. See issue #72.
+                    startTime = queryStart,
                     endTime = queryEnd
                 ))
             }
@@ -1260,7 +1264,8 @@ class HealthConnectManager(private val context: Context) {
             if (dayDistance > 0.0) {
                 result.add(DistanceData(
                     meters = dayDistance,
-                    startTime = dayStart,
+                    // Clamped window start, not local midnight — see issue #72.
+                    startTime = queryStart,
                     endTime = queryEnd
                 ))
             }
@@ -1357,7 +1362,8 @@ class HealthConnectManager(private val context: Context) {
             if (dayCalories > 0.0) {
                 result.add(ActiveCaloriesData(
                     calories = dayCalories,
-                    startTime = dayStart,
+                    // Clamped window start, not local midnight — see issue #72.
+                    startTime = queryStart,
                     endTime = queryEnd
                 ))
             }
@@ -1437,7 +1443,8 @@ class HealthConnectManager(private val context: Context) {
                 result.add(
                     TotalCaloriesData(
                         calories = dayCalories,
-                        startTime = dayStart,
+                        // Clamped window start, not local midnight — see issue #72.
+                        startTime = queryStart,
                         endTime = queryEnd,
                     ),
                 )
@@ -1776,7 +1783,8 @@ class HealthConnectManager(private val context: Context) {
 
             val dayLiters = readRawHydrationData(queryStart, queryEnd, null).sumOf { it.liters }
             if (dayLiters > 0.0) {
-                result.add(HydrationData(dayLiters, dayStart, queryEnd))
+                // Clamped window start, not local midnight — see issue #72.
+                result.add(HydrationData(dayLiters, queryStart, queryEnd))
             }
         }
         return result
@@ -1874,7 +1882,8 @@ class HealthConnectManager(private val context: Context) {
 
             val dayRecords = readRawNutritionData(queryStart, queryEnd, null)
             if (dayRecords.isNotEmpty()) {
-                result.add(mergeNutritionRecords(dayRecords, dayStart, queryEnd))
+                // Clamped window start, not local midnight — see issue #72.
+                result.add(mergeNutritionRecords(dayRecords, queryStart, queryEnd))
             }
         }
         return result


### PR DESCRIPTION
## Summary
The daily-resolution readers (steps, distance, active/total calories, hydration, nutrition) emitted start_time as local midnight even when the lookback window (?days=N) started partway through that day. The oldest bucket therefore counted only the elapsed hours inside the window but looked like a complete calendar day, so consumers keyed on start_time stored a partial total as a full day.

Emit the clamped window start (queryStart) instead of local midnight, so both edges of every bucket reflect the range actually aggregated. end_time already carried the clamped value.
## Related
- Closes #72 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Build/CI change

## Checklist
- [x] I tested this change locally
- [ ] I updated documentation (if needed)
- [ ] I added/updated tests (if needed)
- [ ] I verified there are no breaking changes
- [ ] I checked for sensitive data/secrets
